### PR TITLE
Fix return type of LCMP/[DF]CMP[LG] instructions.

### DIFF
--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/analyzer/InstMethodSinkInterpreter.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/analyzer/InstMethodSinkInterpreter.java
@@ -322,17 +322,23 @@ public class InstMethodSinkInterpreter extends BasicInterpreter {
 		case DMUL:
 		case DDIV:
 		case DREM:
-		case LCMP:
-		case FCMPL:
-		case FCMPG:
-		case DCMPL:
-		case DCMPG:
 			SinkableArrayValue v1 = (SinkableArrayValue) value1;
 			SinkableArrayValue v2 = (SinkableArrayValue) value2;
 			SinkableArrayValue v3 = new SinkableArrayValue(v1.getType());
 			v3.addDep(v1);
 			v3.addDep(v2);
 			return v3;
+                case LCMP:
+                case FCMPL:
+                case FCMPG:
+                case DCMPL:
+                case DCMPG:
+                        v1 = (SinkableArrayValue) value1;
+                        v2 = (SinkableArrayValue) value2;
+                        v3 = new SinkableArrayValue(Type.INT_TYPE);
+                        v3.addDep(v1);
+                        v3.addDep(v2);
+                        return v3;
 		case AALOAD:
 			if (value1.getType() == null) {
 				ret = new SinkableArrayValue(null);


### PR DESCRIPTION
The original version of the code lumped them with instructions
such as FADD, which take two arguments of the same type (e.g.,
float in the case of FADD) and return a result of the same type.

For LCMP, DCMPL, DCMPG, FCMPL and FCMPG, this is incorrect: While they
take two arguments of identical type, they always return an int.

This pull request fixes this by making these five opcodes return the correct type.