### PR TITLE
Implemented disabling the branch not taken in control tracking

### DIFF
--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/Configuration.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/Configuration.java
@@ -24,6 +24,7 @@ public class Configuration {
 	public static boolean IMPLICIT_TRACKING = true; //must be set to TRUE for MULTI_TAINTING to work!
 	public static boolean IMPLICIT_LIGHT_TRACKING;
 	public static boolean IMPLICIT_HEADERS_NO_TRACKING = false;
+	public static boolean WITHOUT_BRANCH_NOT_TAKEN = false;
 
 	public static boolean IMPLICIT_EXCEPTION_FLOW = false;
 

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/Instrumenter.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/Instrumenter.java
@@ -243,6 +243,9 @@ public class Instrumenter {
 	static Option opt_multiTaint = Option.builder("multiTaint")
 		.desc("Support for 2^32 tags instead of just 32")
 		.build();
+	static Option opt_withoutBranchNotTaken = Option.builder("withoutBranchNotTaken")
+			.desc("Disable branch not taken analysis in control tracking")
+			.build();
 	static Option opt_trackArrayLengthTaints = Option.builder("withArrayLengthTags")
 		.desc("Tracks taint tags on array lengths - requires use of JVMTI runtime library when running")
 		.build();
@@ -309,10 +312,10 @@ public class Instrumenter {
 		options.addOption(opt_withSelectiveInst);
 		options.addOption(opt_uninstCopies);
 		options.addOption(opt_disableJumpOptimizations);
-	    options.addOption(opt_readAndSaveBCI);
-	    options.addOption(opt_serialization);
+		options.addOption(opt_readAndSaveBCI);
+		options.addOption(opt_serialization);
+		options.addOption(opt_withoutBranchNotTaken);
 
-	    
 		CommandLineParser parser = new BasicParser();
 	    CommandLine line = null;
 	    try {
@@ -360,6 +363,7 @@ public class Instrumenter {
 //		Configuration.TAINT_THROUGH_SERIALIZATION = line.hasOption("serialization"); //Really needs to always be active
 		
 		Configuration.ARRAY_INDEX_TRACKING = line.hasOption("withArrayIndexTags");
+		Configuration.WITHOUT_BRANCH_NOT_TAKEN = line.hasOption("withoutBranchNotTaken");
 		Configuration.init();
 
 		
@@ -384,6 +388,13 @@ public class Instrumenter {
 		if (Configuration.WITH_SELECTIVE_INST) {
 			System.out.println("Loading selective instrumentation configuration");
 			SelectiveInstrumentationManager.populateMethodsToInstrument(Configuration.selective_inst_config);
+		}
+
+		if(Configuration.WITHOUT_BRANCH_NOT_TAKEN) {
+			System.out.println("Branch not taken: disabled");
+		}
+		else {
+			System.out.println("Branch not taken: enabled");
 		}
 
 		TaintTrackingClassVisitor.IS_RUNTIME_INST = false;

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/PreMain.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/PreMain.java
@@ -526,6 +526,8 @@ public class PreMain {
 					Configuration.IMPLICIT_EXCEPTION_FLOW = true;
 				} else if (s.startsWith("ignore=")) {
 					Configuration.ADDL_IGNORE = s.substring(7);
+				} else if (s.equals("withoutBranchNotTaken")) {
+					Configuration.WITHOUT_BRANCH_NOT_TAKEN = true;
 				}
 			}
 		}

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/TaintPassingMV.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/TaintPassingMV.java
@@ -828,6 +828,12 @@ public class TaintPassingMV extends TaintAdapter implements Opcodes {
 
 
 	public void doForceCtrlStores(){
+		if(Configuration.WITHOUT_BRANCH_NOT_TAKEN) {
+			forceCtrlStoreFields.clear();
+			forceCtrlAdd.clear();
+			return;
+		}
+
 		MethodVisitor ta = mv;
 
 		for(String t : exceptionsToMaybeThrow){

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/TaintPassingMV.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/TaintPassingMV.java
@@ -2446,6 +2446,10 @@ public class TaintPassingMV extends TaintAdapter implements Opcodes {
 			return;
 		}
 		if (opcode == TaintUtils.FORCE_CTRL_STORE) {
+			if(Configuration.WITHOUT_BRANCH_NOT_TAKEN) {
+				return;
+			}
+
 			//If there is anything on the stack right now, apply the current marker to it
 			if (analyzer.stack.isEmpty() || topOfStackIsNull())
 				return;


### PR DESCRIPTION
The implementation is guarded by an option -withoutBranchNotTaken.