### PR TITLE
Added missing CharacterUtils method

### DIFF
--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/CharacterUtils.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/CharacterUtils.java
@@ -449,7 +449,12 @@ public class CharacterUtils {
 	}
 
 	public static TaintedIntWithIntTag toChars$$PHOSPHORTAGGED(int idxTaint, int idx, LazyCharArrayIntTags[] artags, char[] ar, int t, int dstIdx, TaintedIntWithIntTag ret) {
+		ret.val = Character.toChars(idx, ar, dstIdx);
+		ret.taint = idxTaint;
+		return ret;
+	}
 
+	public static TaintedIntWithIntTag toChars$$PHOSPHORTAGGED(int idxTaint, int idx, LazyCharArrayIntTags artags, char[] ar, int t, int dstIdx, TaintedIntWithIntTag ret) {
 		ret.val = Character.toChars(idx, ar, dstIdx);
 		ret.taint = idxTaint;
 		return ret;
@@ -547,5 +552,3 @@ public class CharacterUtils {
 		return ret;
 	}
 }
-
-

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/CharacterUtils.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/CharacterUtils.java
@@ -448,12 +448,6 @@ public class CharacterUtils {
 		return ret;
 	}
 
-	public static TaintedIntWithIntTag toChars$$PHOSPHORTAGGED(int idxTaint, int idx, LazyCharArrayIntTags[] artags, char[] ar, int t, int dstIdx, TaintedIntWithIntTag ret) {
-		ret.val = Character.toChars(idx, ar, dstIdx);
-		ret.taint = idxTaint;
-		return ret;
-	}
-
 	public static TaintedIntWithIntTag toChars$$PHOSPHORTAGGED(int idxTaint, int idx, LazyCharArrayIntTags artags, char[] ar, int t, int dstIdx, TaintedIntWithIntTag ret) {
 		ret.val = Character.toChars(idx, ar, dstIdx);
 		ret.taint = idxTaint;


### PR DESCRIPTION
I instrumented Lucene with int-tags and got the following error:

```
Exception in thread "main" java.lang.NoSuchMethodError: edu.columbia.cs.psl.phosphor.runtime.CharacterUtils.toChars$$PHOSPHORTAGGED(IILedu/columbia/cs/psl/phosphor/struct/LazyCharArrayIntTags;[CIILedu/columbia/cs/psl/phosphor/struct/TaintedIntWithIntTag;)Ledu/columbia/cs/psl/phosphor/struct/TaintedIntWithIntTag;
	at org.apache.lucene.analysis.CharacterUtils.toLowerCase$$PHOSPHORTAGGED(CharacterUtils.java:58)
	at org.apache.lucene.analysis.LowerCaseFilter.incrementToken$$PHOSPHORTAGGED(LowerCaseFilter.java:45)
	at org.apache.lucene.analysis.FilteringTokenFilter.incrementToken$$PHOSPHORTAGGED(FilteringTokenFilter.java:49)
	at org.apache.lucene.index.DefaultIndexingChain$PerField.invert$$PHOSPHORTAGGED(DefaultIndexingChain.java:738)
	at org.apache.lucene.index.DefaultIndexingChain.processField$$PHOSPHORTAGGED(DefaultIndexingChain.java:428)
	at org.apache.lucene.index.DefaultIndexingChain.processDocument(DefaultIndexingChain.java:392)
	at org.apache.lucene.index.DocumentsWriterPerThread.updateDocument$$PHOSPHORTAGGED(DocumentsWriterPerThread.java:251)
	at org.apache.lucene.index.DocumentsWriter.updateDocument$$PHOSPHORTAGGED(DocumentsWriter.java:494)
	at org.apache.lucene.index.IndexWriter.updateDocument$$PHOSPHORTAGGED(IndexWriter.java:1602)
	at org.apache.lucene.index.IndexWriter.addDocument$$PHOSPHORTAGGED(IndexWriter.java:1221)
	at edu.cmu.cs.mvelezce.IndexFiles.indexDoc$$PHOSPHORTAGGED(IndexFiles.java:212)
	at edu.cmu.cs.mvelezce.IndexFiles$1.visitFile(IndexFiles.java:162)
	at edu.cmu.cs.mvelezce.IndexFiles$1.visitFile(IndexFiles.java:157)
	at java.nio.file.Files.walkFileTree$$PHOSPHORTAGGED(Files.java:2670)
	at java.nio.file.Files.walkFileTree(Files.java:2742)
	at edu.cmu.cs.mvelezce.IndexFiles.indexDocs(IndexFiles.java:155)
	at edu.cmu.cs.mvelezce.IndexFiles.main(IndexFiles.java:119)
```

The new method has the same behavior as the method at line 451, but I changed the signature to match the one of the error message above.