### PR TITLE
fixed how to set the taint in a string

### DIFF
--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/Taint.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/Taint.java
@@ -255,7 +255,7 @@ public class Taint<T> implements Serializable {
 			if(o instanceof String)
 			{
 				Taint onObj  = (Taint) ((TaintedWithObjTag)o).getPHOSPHOR_TAG();
-				((String) o).PHOSPHOR_TAG = Taint.combineTags(onObj, tags);
+				((String) o).setPHOSPHOR_TAG(Taint.combineTags(onObj, tags));
 //				for(int i = 0; i < ((String) o).length(); i++)
 //				{
 //					((String)o).valuePHOSPHOR_TAG[i] = Taint.combineTags(((String)o).valuePHOSPHOR_TAG[i], tags);


### PR DESCRIPTION
Setting a taint in a string in Taint.combineTagsOnObject was only setting the String.PHOSPHOR_TAG field, not calling the set method. This behavior caused the taint to be missed at a sink. The missed taint occurred in TaintSourceWrapper.checkTaint(Object obj, String sink) at line 194. The conditional checks for String.valuePHOSPHOR_TAG, which was not changed when tainting and object in Taint.combineTagsOnObject.