### PR TITLE
Integration Test to confirm TaintThrough handles non-tainted obj case.

### DIFF
--- a/Phosphor/.gitignore
+++ b/Phosphor/.gitignore
@@ -4,3 +4,42 @@
 .classpath
 .settings
 dacapo
+test.tmp.out
+
+# Remove dynamically generated pom
+dependency-reduced-pom.xml
+
+# Ignore vim .swp files
+**/*.swp
+
+
+# Ignore intellij stuff
+*.iml
+.idea
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/AutoTaintObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/AutoTaintObjTagITCase.java
@@ -37,6 +37,25 @@ public class AutoTaintObjTagITCase extends BaseMultiTaintClass {
 
 
 	@Test
+	public void testTaintThroughHandlesUntaintedObject() throws Exception{
+
+		try {
+
+			TaintThroughExample ex = new TaintThroughExample();
+
+			int[] ar = new int[10];
+
+			ex.taintBackToArgs(ar);
+
+			assertNullOrEmpty(MultiTainter.getTaint(ar[0]));
+			assertNullOrEmpty(MultiTainter.getTaint(ar[1]));
+		}
+		catch (NullPointerException ex) {
+			fail(ex.toString());
+		}
+	}
+
+	@Test
 	public void testTaintThroughAppliesToArgsAtEndOfMethod() throws Exception{
 		TaintThroughExample ex = new TaintThroughExample();
 		MultiTainter.taintedObject(ex,new Taint("Test"));


### PR DESCRIPTION
Fails with NPE before merging @katherine-hough changes. This took a while primarily because I wanted to step through the test in Intellij prior to making this PR.

There are some .gitignore improvements as an extra incentive!