### PR TITLE
Added check that newArgs is not empty before calling newArgs.getLast

### DIFF
--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/TaintTrackingClassVisitor.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/TaintTrackingClassVisitor.java
@@ -976,7 +976,7 @@ public class TaintTrackingClassVisitor extends ClassVisitor {
 				if(returnType.getSort() == Type.VOID)
 				{
 					//Check to see if we are one of those annying lambdas with a void return but pre-allocated return obj passed
-					if(newArgs.getLast().getDescriptor().startsWith("Ledu/columbia/cs/psl/phosphor/struct/Tainted")){
+					if(!newArgs.isEmpty() && newArgs.getLast().getDescriptor().startsWith("Ledu/columbia/cs/psl/phosphor/struct/Tainted")){
 						returnTypeToHackOnLambda = newArgs.removeLast();
 					}
 				}
@@ -1050,7 +1050,7 @@ public class TaintTrackingClassVisitor extends ClassVisitor {
 				if(returnType.getSort() == Type.VOID)
 				{
 					//Check to see if we are one of those annying lambdas with a void return but pre-allocated return obj passed
-					if(newArgs.getLast().getDescriptor().startsWith("Ledu/columbia/cs/psl/phosphor/struct/Tainted")){
+					if(!newArgs.isEmpty() && newArgs.getLast().getDescriptor().startsWith("Ledu/columbia/cs/psl/phosphor/struct/Tainted")){
 						newArgs.removeLast();
 					}
 				}

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/LambdaObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/LambdaObjTagITCase.java
@@ -48,6 +48,16 @@ public class LambdaObjTagITCase {
 	}
 
 	@Test
+	public void testZeroArgVoidWrappedLambda() throws Exception {
+		int[] i = new int[1];
+		Runnable r = () -> {
+			i[0] += 10;
+		};
+		r.run();
+		assertTrue("Expected runnable constructed using lambda to run.", i[0] == 10);
+	}
+
+	@Test
 	public void testLambdaIntArg() throws Exception {
 		intArg(new int[10]);
 	}


### PR DESCRIPTION
Added check that newArgs is not empty before calling newArgs.getLast to prevent a NoSuchElementException when checking for lambdas with a void return with a pre-allocated return obj passed to them. Added test case that was failing prior to this change.