### PR TITLE
Ensured that calls to checkTaint for a sink occur before taint tags a…

### DIFF
--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/SinkTaintingMV.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/SinkTaintingMV.java
@@ -35,6 +35,7 @@ public class SinkTaintingMV extends MethodVisitor implements Opcodes {
 
     @Override
     public void visitCode() {
+        super.visitCode();
         // Check every arg to see if is taint tag
         Type[] args = Type.getArgumentTypes(desc);
         int idx = isStatic ? 0 : 1; // skip over the "this" argument for non-static methods

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/SourceSinkTaintingClassVisitor.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/SourceSinkTaintingClassVisitor.java
@@ -31,14 +31,6 @@ public class SourceSinkTaintingClassVisitor extends ClassVisitor {
         MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
         if(((access & Opcodes.ACC_NATIVE) == 0) && (name.contains(TaintUtils.METHOD_SUFFIX)) || !containsPrimitiveType(desc)) {
             // Method is not a native method and it is not a method for which $$PHOSPHORTAGGED version should have been created.
-            if(BasicSourceSinkManager.getInstance().isSource(className, name, desc)) {
-                // Method is a source
-                mv = new SourceTaintingMV(mv, access, className, name, desc);
-            }
-            if(BasicSourceSinkManager.getInstance().isTaintThrough(className, name, desc)) {
-                // Method is a taintThrough method
-                mv = new TaintThroughTaintingMV(mv, access, className, name, desc);
-            }
             if(BasicSourceSinkManager.getInstance().isSink(className, name, desc)) {
                 // Method is a sink
                 final SinkTaintingMV sinkMV = new SinkTaintingMV(mv, access, className, name, desc);
@@ -50,6 +42,14 @@ public class SourceSinkTaintingClassVisitor extends ClassVisitor {
                         this.accept(sinkMV);
                     }
                 };
+            }
+            if(BasicSourceSinkManager.getInstance().isSource(className, name, desc)) {
+                // Method is a source
+                mv = new SourceTaintingMV(mv, access, className, name, desc);
+            }
+            if(BasicSourceSinkManager.getInstance().isTaintThrough(className, name, desc)) {
+                // Method is a taintThrough method
+                mv = new TaintThroughTaintingMV(mv, access, className, name, desc);
             }
         }
         return mv;

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/TaintThroughTaintingMV.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/TaintThroughTaintingMV.java
@@ -30,9 +30,8 @@ public class TaintThroughTaintingMV extends MethodVisitor implements Opcodes {
 
     @Override
     public void visitCode() {
-        taintArguments();
         super.visitCode();
-
+        taintArguments();
     }
 
     /* Adds code to add this instance's taint tags to the arguments passed to this method. */


### PR DESCRIPTION
…pplied to arguments from source or taintThrough code (if a method is both a sink and a source or taintThrough method). Fixed incorrectly ordered or missing calls to super.visitCode() whoops.