### PR TITLE
TaintSourceWrapper autoTaint and checkTaint changes

### DIFF
--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/BasicSourceSinkManager.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/BasicSourceSinkManager.java
@@ -248,4 +248,12 @@ public class BasicSourceSinkManager extends SourceSinkManager {
 			return getAutoTaintMethods(parsed[0], sinks, inheritedSinks).contains(parsed[1]);
 		}
 	}
+
+	/* Returns the name of sink method from which the specified method inherited its sink property or null if the specified
+	 * method is not a sink. */
+	public String getBaseSink(String str) {
+		String[] parsed = str.split("\\.");
+		String baseSink = findSuperTypeAutoTaintProvider(parsed[0], parsed[1], sinks, inheritedSinks);
+		return baseSink == null ? null : String.format("%s.%s", baseSink, parsed[1]);
+	}
 }

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/Instrumenter.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/Instrumenter.java
@@ -776,7 +776,7 @@ public class Instrumenter {
 					try {
 						r = fr.get();
 						break;
-					} catch (InterruptedException e) {
+					} catch (InterruptedException _) {
 						continue;
 					}
 				}

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/Instrumenter.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/Instrumenter.java
@@ -776,7 +776,7 @@ public class Instrumenter {
 					try {
 						r = fr.get();
 						break;
-					} catch (InterruptedException _) {
+					} catch (InterruptedException e) {
 						continue;
 					}
 				}

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/NullSourceSinkManager.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/NullSourceSinkManager.java
@@ -27,4 +27,8 @@ public class NullSourceSinkManager extends SourceSinkManager{
 		return false;
 	}
 
+	@Override
+	public String getBaseSink(String str) {
+		return null;
+	}
 }

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/SourceSinkManager.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/SourceSinkManager.java
@@ -191,4 +191,15 @@ public abstract class SourceSinkManager {
 		else
 			return isSource(owner + "." + name + taintedDesc);
 	}
+
+	/* Returns the name of sink method from which the specified method inherited its sink property or null if the specified
+	 * method is not a sink. */
+	public String getBaseSink(String owner, String name, String taintedDesc) {
+		if (name.endsWith("$$PHOSPHORTAGGED"))
+			return getBaseSink(owner + "." + name.replace("$$PHOSPHORTAGGED", "") + remapMethodDescToRemoveTaints(taintedDesc));
+		else
+			return getBaseSink(owner + "." + name + taintedDesc);
+	}
+
+	public abstract String getBaseSink(String str);
 }

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/SourceSinkManager.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/SourceSinkManager.java
@@ -68,7 +68,7 @@ public abstract class SourceSinkManager {
 		boolean isSkipping = false;
 		for (Type t : Type.getArgumentTypes(desc)) {
 			if (t.getSort() == Type.ARRAY) {
-				r += t.getDescriptor();
+				r += remapReturnType(t);
 			} else if (t.getSort() != Type.OBJECT) {
 				if (!isSkipping)
 					isSkipping = true;
@@ -92,7 +92,7 @@ public abstract class SourceSinkManager {
 	}
 
 	private static String remapReturnType(Type returnType) {
-		if (returnType.getSort() == Type.OBJECT) {
+		if (returnType.getSort() == Type.OBJECT || returnType.getSort() == Type.ARRAY) {
 			if (returnType.getInternalName().startsWith("edu/columbia/cs/psl/phosphor/struct/multid")) {
 				return MultiDTaintedArray.getPrimitiveTypeForWrapper(returnType.getInternalName()).getDescriptor();
 			}
@@ -100,71 +100,71 @@ public abstract class SourceSinkManager {
 			{
 				if (returnType.getInternalName().equals(Type.getInternalName(TaintedByteWithObjTag.class)))
 					return "B";
-				if (returnType.getInternalName().equals(Type.getInternalName(LazyByteArrayObjTags.class)))
-					return "[B";
+				if (returnType.getDescriptor().contains(Type.getDescriptor(LazyByteArrayObjTags.class)))
+					return returnType.getDescriptor().replace(Type.getDescriptor(LazyByteArrayObjTags.class), "[B");
 				if (returnType.getInternalName().equals(Type.getInternalName(TaintedBooleanWithObjTag.class)))
 					return "Z";
-				if (returnType.getInternalName().equals(Type.getInternalName(LazyBooleanArrayObjTags.class)))
-					return "[Z";
+				if (returnType.getDescriptor().contains(Type.getDescriptor(LazyBooleanArrayObjTags.class)))
+					return returnType.getDescriptor().replace(Type.getDescriptor(LazyBooleanArrayObjTags.class), "[Z");
 				if (returnType.getInternalName().equals(Type.getInternalName(TaintedCharWithObjTag.class)))
 					return "C";
-				if (returnType.getInternalName().equals(Type.getInternalName(LazyCharArrayObjTags.class)))
-					return "[C";
+				if (returnType.getDescriptor().contains(Type.getDescriptor(LazyCharArrayObjTags.class)))
+					return returnType.getDescriptor().replace(Type.getDescriptor(LazyCharArrayObjTags.class), "[C");
 				if (returnType.getInternalName().equals(Type.getInternalName(TaintedDoubleWithObjTag.class)))
 					return "D";
-				if (returnType.getInternalName().equals(Type.getInternalName(LazyDoubleArrayObjTags.class)))
-					return "[D";
+				if (returnType.getDescriptor().contains(Type.getDescriptor(LazyDoubleArrayObjTags.class)))
+					return returnType.getDescriptor().replace(Type.getDescriptor(LazyDoubleArrayObjTags.class), "[D");
 				if (returnType.getInternalName().equals(Type.getInternalName(TaintedIntWithObjTag.class)))
 					return "I";
-				if (returnType.getInternalName().equals(Type.getInternalName(LazyIntArrayObjTags.class)))
-					return "[I";
+				if (returnType.getDescriptor().contains(Type.getDescriptor(LazyIntArrayObjTags.class)))
+					return returnType.getDescriptor().replace(Type.getDescriptor(LazyIntArrayObjTags.class), "[I");
 				if (returnType.getInternalName().equals(Type.getInternalName(TaintedFloatWithObjTag.class)))
 					return "F";
-				if (returnType.getInternalName().equals(Type.getInternalName(LazyFloatArrayObjTags.class)))
-					return "[F";
+				if (returnType.getDescriptor().contains(Type.getDescriptor(LazyFloatArrayObjTags.class)))
+					return returnType.getDescriptor().replace(Type.getDescriptor(LazyFloatArrayObjTags.class), "[F");
 				if (returnType.getInternalName().equals(Type.getInternalName(TaintedLongWithObjTag.class)))
 					return "J";
-				if (returnType.getInternalName().equals(Type.getInternalName(LazyLongArrayObjTags.class)))
-					return "[J";
+				if (returnType.getDescriptor().contains(Type.getDescriptor(LazyLongArrayObjTags.class)))
+					return returnType.getDescriptor().replace(Type.getDescriptor(LazyLongArrayObjTags.class), "[J");
 				if (returnType.getInternalName().equals(Type.getInternalName(TaintedShortWithObjTag.class)))
 					return "S";
-				if (returnType.getInternalName().equals(Type.getInternalName(LazyShortArrayObjTags.class)))
-					return "[S";
+				if (returnType.getDescriptor().contains(Type.getDescriptor(LazyShortArrayObjTags.class)))
+					return returnType.getDescriptor().replace(Type.getDescriptor(LazyShortArrayObjTags.class), "[S");
 			}
 			else
 			{
 				if (returnType.getInternalName().equals(Type.getInternalName(TaintedByteWithIntTag.class)))
 					return "B";
-				if (returnType.getInternalName().equals(Type.getInternalName(LazyByteArrayIntTags.class)))
-					return "[B";
+				if (returnType.getDescriptor().contains(Type.getDescriptor(LazyByteArrayIntTags.class)))
+					return returnType.getDescriptor().replace(Type.getDescriptor(LazyByteArrayIntTags.class), "[B");
 				if (returnType.getInternalName().equals(Type.getInternalName(TaintedBooleanWithIntTag.class)))
 					return "Z";
-				if (returnType.getInternalName().equals(Type.getInternalName(LazyBooleanArrayIntTags.class)))
-					return "[Z";
+				if (returnType.getDescriptor().contains(Type.getDescriptor(LazyBooleanArrayIntTags.class)))
+					return returnType.getDescriptor().replace(Type.getDescriptor(LazyBooleanArrayIntTags.class), "[Z");
 				if (returnType.getInternalName().equals(Type.getInternalName(TaintedCharWithIntTag.class)))
 					return "C";
-				if (returnType.getInternalName().equals(Type.getInternalName(LazyCharArrayIntTags.class)))
-					return "[C";
+				if (returnType.getDescriptor().contains(Type.getDescriptor(LazyCharArrayIntTags.class)))
+					return returnType.getDescriptor().replace(Type.getDescriptor(LazyCharArrayIntTags.class), "[C");
 				if (returnType.getInternalName().equals(Type.getInternalName(TaintedDoubleWithIntTag.class)))
 					return "D";
-				if (returnType.getInternalName().equals(Type.getInternalName(LazyDoubleArrayIntTags.class)))
-					return "[D";
+				if (returnType.getDescriptor().contains(Type.getDescriptor(LazyDoubleArrayIntTags.class)))
+					return returnType.getDescriptor().replace(Type.getDescriptor(LazyDoubleArrayIntTags.class), "[D");
 				if (returnType.getInternalName().equals(Type.getInternalName(TaintedIntWithIntTag.class)))
 					return "I";
-				if (returnType.getInternalName().equals(Type.getInternalName(LazyIntArrayIntTags.class)))
-					return "[I";
+				if (returnType.getDescriptor().contains(Type.getDescriptor(LazyIntArrayIntTags.class)))
+					return returnType.getDescriptor().replace(Type.getDescriptor(LazyIntArrayIntTags.class), "[I");
 				if (returnType.getInternalName().equals(Type.getInternalName(TaintedFloatWithIntTag.class)))
 					return "F";
-				if (returnType.getInternalName().equals(Type.getInternalName(LazyFloatArrayIntTags.class)))
-					return "[F";
+				if (returnType.getDescriptor().contains(Type.getDescriptor(LazyFloatArrayIntTags.class)))
+					return returnType.getDescriptor().replace(Type.getDescriptor(LazyFloatArrayIntTags.class), "[F");
 				if (returnType.getInternalName().equals(Type.getInternalName(TaintedLongWithIntTag.class)))
 					return "J";
-				if (returnType.getInternalName().equals(Type.getInternalName(LazyLongArrayIntTags.class)))
-					return "[J";
+				if (returnType.getDescriptor().contains(Type.getDescriptor(LazyLongArrayIntTags.class)))
+					return returnType.getDescriptor().replace(Type.getDescriptor(LazyLongArrayIntTags.class), "[J");
 				if (returnType.getInternalName().equals(Type.getInternalName(TaintedShortWithIntTag.class)))
 					return "S";
-				if (returnType.getInternalName().equals(Type.getInternalName(LazyShortArrayIntTags.class)))
-					return "[S";
+				if (returnType.getDescriptor().contains(Type.getDescriptor(LazyShortArrayIntTags.class)))
+					return returnType.getDescriptor().replace(Type.getDescriptor(LazyShortArrayIntTags.class), "[S");
 			}
 		}
 		return returnType.getDescriptor();

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/SourceTaintingMV.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/SourceTaintingMV.java
@@ -3,6 +3,7 @@ package edu.columbia.cs.psl.phosphor.instrumenter;
 import edu.columbia.cs.psl.phosphor.*;
 import edu.columbia.cs.psl.phosphor.runtime.TaintChecker;
 import edu.columbia.cs.psl.phosphor.runtime.TaintSourceWrapper;
+import edu.columbia.cs.psl.phosphor.struct.LazyArrayObjTags;
 import edu.columbia.cs.psl.phosphor.struct.TaintedPrimitiveWithIntTag;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -65,6 +66,11 @@ public class SourceTaintingMV extends MethodVisitor implements Opcodes {
 				super.visitVarInsn(ALOAD, idx);
 				loadSourceLblAndMakeTaint();
 				super.visitMethodInsn(INVOKEVIRTUAL, Type.getInternalName(TaintSourceWrapper.class), "combineTaintsOnArray", "(Ljava/lang/Object;" + Configuration.TAINT_TAG_DESC + ")V", false);
+			} else if (TaintUtils.isPrimitiveArrayType(args[i])) {
+				super.visitVarInsn(ALOAD, idx-args[i-1].getSize());
+				super.visitMethodInsn(INVOKEVIRTUAL, Type.getInternalName(LazyArrayObjTags.class), "getVal", "()Ljava/lang/Object;", false);
+				super.visitTypeInsn(CHECKCAST, args[i].getInternalName());
+				super.visitVarInsn(ASTORE, idx);
 			}
 			idx += args[i].getSize();
 		}

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/SourceTaintingMV.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/SourceTaintingMV.java
@@ -3,7 +3,6 @@ package edu.columbia.cs.psl.phosphor.instrumenter;
 import edu.columbia.cs.psl.phosphor.*;
 import edu.columbia.cs.psl.phosphor.runtime.TaintChecker;
 import edu.columbia.cs.psl.phosphor.runtime.TaintSourceWrapper;
-import edu.columbia.cs.psl.phosphor.struct.LazyArrayObjTags;
 import edu.columbia.cs.psl.phosphor.struct.TaintedPrimitiveWithIntTag;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -66,11 +65,6 @@ public class SourceTaintingMV extends MethodVisitor implements Opcodes {
 				super.visitVarInsn(ALOAD, idx);
 				loadSourceLblAndMakeTaint();
 				super.visitMethodInsn(INVOKEVIRTUAL, Type.getInternalName(TaintSourceWrapper.class), "combineTaintsOnArray", "(Ljava/lang/Object;" + Configuration.TAINT_TAG_DESC + ")V", false);
-			} else if (TaintUtils.isPrimitiveArrayType(args[i])) {
-				super.visitVarInsn(ALOAD, idx-args[i-1].getSize());
-				super.visitMethodInsn(INVOKEVIRTUAL, Type.getInternalName(LazyArrayObjTags.class), "getVal", "()Ljava/lang/Object;", false);
-				super.visitTypeInsn(CHECKCAST, args[i].getInternalName());
-				super.visitVarInsn(ASTORE, idx);
 			}
 			idx += args[i].getSize();
 		}

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/TaintThroughTaintingMV.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/TaintThroughTaintingMV.java
@@ -2,7 +2,6 @@ package edu.columbia.cs.psl.phosphor.instrumenter;
 
 import edu.columbia.cs.psl.phosphor.*;
 import edu.columbia.cs.psl.phosphor.runtime.Taint;
-import edu.columbia.cs.psl.phosphor.runtime.TaintChecker;
 import edu.columbia.cs.psl.phosphor.runtime.TaintSourceWrapper;
 import edu.columbia.cs.psl.phosphor.struct.TaintedPrimitiveWithIntTag;
 import edu.columbia.cs.psl.phosphor.struct.TaintedPrimitiveWithObjTag;

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/TaintSourceWrapper.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/TaintSourceWrapper.java
@@ -118,7 +118,8 @@ public class TaintSourceWrapper<T extends AutoTaintLabel> {
 		}
 	}
 
-	public void checkTaint(int tag, String baseSink, String actualSink) {
+
+	public void checkTaint(int tag, Object obj, String baseSink, String actualSink) {
 		if (tag != 0)
 			throw new IllegalAccessError("Argument carries taint " + tag + " at " + actualSink);
 	}
@@ -128,9 +129,9 @@ public class TaintSourceWrapper<T extends AutoTaintLabel> {
 			throw new IllegalAccessError("Argument carries taint " + tag);
 	}
 
-	public void checkTaint(Taint<T> tag, String baseSink, String actualSink) {
+	public void checkTaint(Taint<T> tag, Object obj, String baseSink, String actualSink) {
 		if (tag != null)
-			taintViolation(tag, null, baseSink, actualSink);
+			taintViolation(tag, obj, baseSink, actualSink);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/TaintSourceWrapper.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/TaintSourceWrapper.java
@@ -79,11 +79,11 @@ public class TaintSourceWrapper<T extends AutoTaintLabel> {
 
     @SuppressWarnings("unchecked")
 	public TaintedWithObjTag autoTaint(TaintedWithObjTag ret, String source, int argIdx) {
-        Taint prevTag = (Taint)((TaintedWithObjTag) ret).getPHOSPHOR_TAG();
+        Taint prevTag = (Taint)ret.getPHOSPHOR_TAG();
         if(prevTag != null) {
             prevTag.addDependency(generateTaint(source));
         } else {
-            ((TaintedWithObjTag) ret).setPHOSPHOR_TAG(generateTaint(source));
+            ret.setPHOSPHOR_TAG(generateTaint(source));
         }
         return ret;
     }

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/TaintSourceWrapper.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/TaintSourceWrapper.java
@@ -129,15 +129,25 @@ public class TaintSourceWrapper<T extends AutoTaintLabel> {
 			throw new IllegalAccessError("Argument carries taint " + tag);
 	}
 
+	public Taint[] getStringValueTaints(String str) {
+		if(str == null) {
+			return null;
+		} else {
+			return((String)str).valuePHOSPHOR_TAG.taints;
+
+		}
+	}
+
 	@SuppressWarnings("unchecked")
 	public void checkTaint(Object obj, String baseSink, String actualSink) {
 		if (obj == null)
 			return;
 		if (obj instanceof String) {
 			if (obj instanceof TaintedWithObjTag) {
-				if (obj != null && ((String) obj).valuePHOSPHOR_TAG != null && ((String) obj).valuePHOSPHOR_TAG.taints != null) {
+				Taint[] taints = getStringValueTaints((String) obj);
+				if (taints != null) {
 					SimpleHashSet<String> reported = new SimpleHashSet<>();
-					for (Taint t : ((String) obj).valuePHOSPHOR_TAG.taints) {
+					for (Taint t : taints) {
 						if (t != null) {
 							String _t = new String(t.toString().getBytes());
 							if (reported.add(_t))

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/TaintSourceWrapper.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/TaintSourceWrapper.java
@@ -129,11 +129,6 @@ public class TaintSourceWrapper<T extends AutoTaintLabel> {
 			throw new IllegalAccessError("Argument carries taint " + tag);
 	}
 
-	public void checkTaint(Taint<T> tag, Object obj, String baseSink, String actualSink) {
-		if (tag != null)
-			taintViolation(tag, obj, baseSink, actualSink);
-	}
-
 	@SuppressWarnings("unchecked")
 	public void checkTaint(Object obj, String baseSink, String actualSink) {
 		if (obj == null)
@@ -186,6 +181,14 @@ public class TaintSourceWrapper<T extends AutoTaintLabel> {
 			}
 		} else if (obj instanceof Taint) {
 			taintViolation((Taint<T>) obj, null, baseSink, actualSink);
+		} else if (obj instanceof TaintedPrimitiveWithObjTag) {
+			if(((TaintedPrimitiveWithObjTag)obj).taint != null) {
+				taintViolation(((TaintedPrimitiveWithObjTag)obj).taint, ((TaintedPrimitiveWithObjTag)obj).getValue(), baseSink, actualSink);
+			}
+		} else if (obj instanceof TaintedPrimitiveWithIntTag) {
+			if(((TaintedPrimitiveWithIntTag)obj).taint != 0) {
+				throw new IllegalAccessError("Argument carries taint " + ((TaintedPrimitiveWithIntTag)obj).taint);
+			}
 		}
 	}
 

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/TaintSourceWrapper.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/TaintSourceWrapper.java
@@ -23,10 +23,6 @@ import edu.columbia.cs.psl.phosphor.struct.*;
  */
 public class TaintSourceWrapper<T extends AutoTaintLabel> {
 
-	public void taintViolation(Taint<T> tag, Object obj, String sink) {
-		throw new TaintSinkError(tag, obj);
-	}
-
 	public void combineTaintsOnArray(Object inputArray, Taint<T> tag){
 		if(tag == null) {
 			return;
@@ -69,79 +65,36 @@ public class TaintSourceWrapper<T extends AutoTaintLabel> {
 		return new Taint<AutoTaintLabel>(new AutoTaintLabel(source, s));
 	}
 
+
 	public Object autoTaint(Object obj, String source, int argIdx) {
-		if (obj instanceof TaintedWithObjTag)
-			((TaintedWithObjTag) obj).setPHOSPHOR_TAG(generateTaint(source));
-		else if(obj instanceof TaintedPrimitiveWithObjTag)
-			((TaintedPrimitiveWithObjTag)obj).taint = generateTaint(source);
+	    if(obj instanceof LazyArrayObjTags) {
+	        return autoTaint((LazyArrayObjTags) obj, source, argIdx);
+        } else if(obj instanceof TaintedWithObjTag) {
+            return autoTaint((TaintedWithObjTag) obj, source, argIdx);
+        } else if(obj instanceof TaintedPrimitiveWithObjTag) {
+            return autoTaint((TaintedPrimitiveWithObjTag) obj, source, argIdx);
+        }
 		return obj;
 	}
 
-	@SuppressWarnings("unchecked")
-	public TaintedIntWithObjTag autoTaint(TaintedIntWithObjTag ret, String source, int argIdx) {
-		if (ret.taint != null)
-			ret.taint.addDependency(generateTaint(source));
-		else
-			ret.taint = generateTaint(source);
+    @SuppressWarnings("unchecked")
+	public TaintedWithObjTag autoTaint(TaintedWithObjTag ret, String source, int argIdx) {
+        Taint prevTag = (Taint)((TaintedWithObjTag) ret).getPHOSPHOR_TAG();
+        if(prevTag != null) {
+            prevTag.addDependency(generateTaint(source));
+        } else {
+            ((TaintedWithObjTag) ret).setPHOSPHOR_TAG(generateTaint(source));
+        }
+        return ret;
+    }
+
+	public LazyArrayObjTags autoTaint(LazyArrayObjTags ret, String source, int argIdx) {
+		setTaints(ret, source);
 		return ret;
 	}
 
 	@SuppressWarnings("unchecked")
-	public TaintedShortWithObjTag autoTaint(TaintedShortWithObjTag ret, String source, int argIdx) {
-		if (ret.taint != null)
-			ret.taint.addDependency(generateTaint(source));
-		else
-			ret.taint = generateTaint(source);
-		return ret;
-	}
-
-	@SuppressWarnings("unchecked")
-	public TaintedLongWithObjTag autoTaint(TaintedLongWithObjTag ret, String source, int argIdx) {
-		if (ret.taint != null)
-			ret.taint.addDependency(generateTaint(source));
-		else
-			ret.taint = generateTaint(source);
-		return ret;
-	}
-
-	@SuppressWarnings("unchecked")
-	public TaintedFloatWithObjTag autoTaint(TaintedFloatWithObjTag ret, String source, int argIdx) {
-		if (ret.taint != null)
-			ret.taint.addDependency(generateTaint(source));
-		else
-			ret.taint = generateTaint(source);
-		return ret;
-	}
-
-	@SuppressWarnings("unchecked")
-	public TaintedDoubleWithObjTag autoTaint(TaintedDoubleWithObjTag ret, String source, int argIdx) {
-		if (ret.taint != null)
-			ret.taint.addDependency(generateTaint(source));
-		else
-			ret.taint = generateTaint(source);
-		return ret;
-	}
-
-	@SuppressWarnings("unchecked")
-	public TaintedBooleanWithObjTag autoTaint(TaintedBooleanWithObjTag ret, String source, int argIdx) {
-		if (ret.taint != null)
-			ret.taint.addDependency(generateTaint(source));
-		else
-			ret.taint = generateTaint(source);
-		return ret;
-	}
-
-	@SuppressWarnings("unchecked")
-	public TaintedByteWithObjTag autoTaint(TaintedByteWithObjTag ret, String source, int argIdx) {
-		if (ret.taint != null)
-			ret.taint.addDependency(generateTaint(source));
-		else
-			ret.taint = generateTaint(source);
-		return ret;
-	}
-
-	@SuppressWarnings("unchecked")
-	public TaintedCharWithObjTag autoTaint(TaintedCharWithObjTag ret, String source, int argIdx) {
+	public TaintedPrimitiveWithObjTag autoTaint(TaintedPrimitiveWithObjTag ret, String source, int argIdx) {
 		if (ret.taint != null)
 			ret.taint.addDependency(generateTaint(source));
 		else
@@ -165,49 +118,9 @@ public class TaintSourceWrapper<T extends AutoTaintLabel> {
 		}
 	}
 
-	public LazyByteArrayObjTags autoTaint(LazyByteArrayObjTags ret, String source, int argIdx) {
-		setTaints(ret, source);
-		return ret;
-	}
-
-	public LazyBooleanArrayObjTags autoTaint(LazyBooleanArrayObjTags ret, String source, int argIdx) {
-		setTaints(ret, source);
-		return ret;
-	}
-
-	public LazyCharArrayObjTags autoTaint(LazyCharArrayObjTags ret, String source, int argIdx) {
-		setTaints(ret, source);
-		return ret;
-	}
-
-	public LazyDoubleArrayObjTags autoTaint(LazyDoubleArrayObjTags ret, String source, int argIdx) {
-		setTaints(ret, source);
-		return ret;
-	}
-
-	public LazyFloatArrayObjTags autoTaint(LazyFloatArrayObjTags ret, String source, int argIdx) {
-		setTaints(ret, source);
-		return ret;
-	}
-
-	public LazyIntArrayObjTags autoTaint(LazyIntArrayObjTags ret, String source, int argIdx) {
-		setTaints(ret, source);
-		return ret;
-	}
-
-	public LazyShortArrayObjTags autoTaint(LazyShortArrayObjTags ret, String source, int argIdx) {
-		setTaints(ret, source);
-		return ret;
-	}
-
-	public LazyLongArrayObjTags autoTaint(LazyLongArrayObjTags ret, String source, int argIdx) {
-		setTaints(ret, source);
-		return ret;
-	}
-
-	public void checkTaint(int tag, String sink) {
+	public void checkTaint(int tag, String baseSink, String actualSink) {
 		if (tag != 0)
-			throw new IllegalAccessError("Argument carries taint " + tag + " at " + sink);
+			throw new IllegalAccessError("Argument carries taint " + tag + " at " + actualSink);
 	}
 
 	public static void checkTaint(int tag) {
@@ -215,13 +128,13 @@ public class TaintSourceWrapper<T extends AutoTaintLabel> {
 			throw new IllegalAccessError("Argument carries taint " + tag);
 	}
 
-	public void checkTaint(Taint<T> tag, String sink) {
+	public void checkTaint(Taint<T> tag, String baseSink, String actualSink) {
 		if (tag != null)
-			taintViolation(tag, null, sink);
+			taintViolation(tag, null, baseSink, actualSink);
 	}
 
 	@SuppressWarnings("unchecked")
-	public void checkTaint(Object obj, String sink) {
+	public void checkTaint(Object obj, String baseSink, String actualSink) {
 		if (obj == null)
 			return;
 		if (obj instanceof String) {
@@ -232,7 +145,7 @@ public class TaintSourceWrapper<T extends AutoTaintLabel> {
 						if (t != null) {
 							String _t = new String(t.toString().getBytes());
 							if (reported.add(_t))
-								taintViolation(t, obj, sink);
+								taintViolation(t, obj, baseSink, actualSink);
 						}
 					}
 				}
@@ -242,7 +155,7 @@ public class TaintSourceWrapper<T extends AutoTaintLabel> {
 				throw new IllegalAccessError("Argument carries taint " + ((TaintedWithIntTag) obj).getPHOSPHOR_TAG());
 		} else if (obj instanceof TaintedWithObjTag) {
 			if (((TaintedWithObjTag) obj).getPHOSPHOR_TAG() != null)
-				taintViolation((Taint<T>) ((TaintedWithObjTag) obj).getPHOSPHOR_TAG(), obj, sink);
+				taintViolation((Taint<T>) ((TaintedWithObjTag) obj).getPHOSPHOR_TAG(), obj, baseSink, actualSink);
 		} else if (obj instanceof int[]) {
 			for (int i : ((int[]) obj)) {
 				if (i > 0)
@@ -260,22 +173,26 @@ public class TaintSourceWrapper<T extends AutoTaintLabel> {
 			if (tags.taints != null)
 				for (Object i : tags.taints) {
 					if (i != null)
-						taintViolation((Taint<T>) i, obj, sink);
+						taintViolation((Taint<T>) i, obj, baseSink, actualSink);
 				}
 		} else if (obj instanceof Object[]) {
 			for (Object o : ((Object[]) obj))
-				checkTaint(o, sink);
+				checkTaint(o, baseSink, actualSink);
 		} else if (obj instanceof ControlTaintTagStack) {
 			ControlTaintTagStack ctrl = (ControlTaintTagStack) obj;
 			if (ctrl.taint != null && !ctrl.isEmpty()) {
-				taintViolation((Taint<T>) ctrl.taint, obj, sink);
+				taintViolation((Taint<T>) ctrl.taint, obj, baseSink, actualSink);
 			}
 		} else if (obj instanceof Taint) {
-			taintViolation((Taint<T>) obj, null, sink);
+			taintViolation((Taint<T>) obj, null, baseSink, actualSink);
 		}
 	}
 
-	public boolean hasTaints(int[] tags) {
+    public void taintViolation(Taint<T> tag, Object obj, String baseSink, String actualSink) {
+        throw new TaintSinkError(tag, obj);
+    }
+
+    public boolean hasTaints(int[] tags) {
 		if (tags == null)
 			return false;
 		for (int i : tags) {


### PR DESCRIPTION
* Changed checkTaint for Taint tags to pass the associated primitive value
* Added getBaseSink to SourceSinkManager which returns the name of the original sink method from which a particular sink inherited its status as a sink.
* Refactored TaintSourceWrapper.autoTaint also changed how it handles tainting TaintedWithObjTag objects
* Changed various sink methods to pass the a string for the base sink in additional to the actual sink being called