### PR TITLE
* Fixed how sources taint array arguments (specifically object arrays…

### DIFF
--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/SourceTaintingMV.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/SourceTaintingMV.java
@@ -39,49 +39,60 @@ public class SourceTaintingMV extends MethodVisitor implements Opcodes {
 		}
 	}
 
-	@Override
-	public void visitCode() {
-		super.visitCode();
+	/* Adds code to make a call to autoTaint. Supplies the specified int as the argument index. Check that the value returned
+	* by the call can be cast to the class with the specified internal name. */
+	private void callAutoTaint(int argIndex, String internalName) {
+		super.visitFieldInsn(GETSTATIC, Type.getInternalName(Configuration.class), "autoTainter", Type.getDescriptor(TaintSourceWrapper.class));
+		super.visitInsn(SWAP);
+		super.visitLdcInsn(lbl);
+		super.visitIntInsn(BIPUSH, argIndex);
+		super.visitMethodInsn(INVOKEVIRTUAL, Type.getInternalName(TaintSourceWrapper.class), "autoTaint", "(Ljava/lang/Object;Ljava/lang/String;I)Ljava/lang/Object;", false);
+		super.visitTypeInsn(CHECKCAST, internalName);
+	}
+
+	/* Adds code to taint the arguments passed to this method. */
+	private void autoTaintArguments() {
 		Type[] args = Type.getArgumentTypes(desc);
 		int idx = isStatic ? 0 : 1; // skip over the "this" argument for non-static methods
 		for (int i = 0; i < args.length; i++) {
-			if (args[i].getSort() == Type.OBJECT) {
-				super.visitVarInsn(ALOAD, idx);
-				if(Configuration.MULTI_TAINTING) {
-					super.visitFieldInsn(GETSTATIC, Type.getInternalName(Configuration.class), "autoTainter", Type.getDescriptor(TaintSourceWrapper.class));
-					super.visitInsn(SWAP);
-					super.visitLdcInsn(lbl);
-					super.visitIntInsn(BIPUSH, i);
-					super.visitMethodInsn(INVOKEVIRTUAL, Type.getInternalName(TaintSourceWrapper.class), "autoTaint", "(Ljava/lang/Object;Ljava/lang/String;I)Ljava/lang/Object;", false);
-					super.visitTypeInsn(CHECKCAST, args[i].getInternalName());
-					super.visitVarInsn(ASTORE, idx);
-				} else {
+			if(Configuration.MULTI_TAINTING) {
+				if(args[i].getSort() == Type.OBJECT || args[i].getSort() == Type.ARRAY && args[i].getElementType().getSort() == Type.OBJECT) {
+					super.visitVarInsn(ALOAD, idx); // load the argument onto the stack
+					callAutoTaint(i, args[i].getInternalName());
+					super.visitVarInsn(ASTORE, idx); // replace the argument with the return of autoTaint
+				}
+			} else {
+				if (args[i].getSort() == Type.OBJECT) {
 					// Int-tags
+                    super.visitVarInsn(ALOAD, idx);
 					loadSourceLblAndMakeTaint();
 					super.visitMethodInsn(INVOKESTATIC, Type.getInternalName(TaintChecker.class), "setTaints", "(Ljava/lang/Object;" + Configuration.TAINT_TAG_DESC + ")V", false);
+				} else if (args[i].getSort() == Type.ARRAY && args[i].getElementType().getSort() == Type.OBJECT) {
+					super.visitVarInsn(ALOAD, idx);
+					loadSourceLblAndMakeTaint();
+					super.visitMethodInsn(INVOKEVIRTUAL, Type.getInternalName(TaintSourceWrapper.class), "combineTaintsOnArray", "(Ljava/lang/Object;" + Configuration.TAINT_TAG_DESC + ")V", false);
 				}
-			} else if (args[i].getSort() == Type.ARRAY
-					&& args[i].getElementType().getSort() == Type.OBJECT) {
-				super.visitVarInsn(ALOAD, idx);
-				loadSourceLblAndMakeTaint();
-				super.visitMethodInsn(INVOKEVIRTUAL, Type.getInternalName(TaintSourceWrapper.class), "combineTaintsOnArray", "(Ljava/lang/Object;" + Configuration.TAINT_TAG_DESC + ")V", false);
 			}
 			idx += args[i].getSize();
 		}
 	}
 
 	@Override
+	public void visitCode() {
+		super.visitCode();
+		autoTaintArguments();
+	}
+
+	@Override
 	public void visitInsn(int opcode) {
+		if (TaintUtils.isReturnOpcode(opcode)) {
+			autoTaintArguments();
+		}
 		if (opcode == ARETURN) {
 			Type boxedReturnType = Type.getReturnType(this.desc);
 			if(Configuration.MULTI_TAINTING && origReturnType.getSort() != Type.VOID) {
-				super.visitFieldInsn(GETSTATIC, Type.getInternalName(Configuration.class), "autoTainter", Type.getDescriptor(TaintSourceWrapper.class));
-				super.visitInsn(SWAP);
-				super.visitLdcInsn(lbl);
-				super.visitInsn(ICONST_M1);
-				super.visitMethodInsn(INVOKEVIRTUAL, Type.getInternalName(TaintSourceWrapper.class), "autoTaint", "(Ljava/lang/Object;Ljava/lang/String;I)Ljava/lang/Object;", false);
-				super.visitTypeInsn(CHECKCAST, boxedReturnType.getInternalName());
-			} else if (origReturnType.getSort() != Type.VOID){
+				callAutoTaint(-1, boxedReturnType.getInternalName());
+			} else if (origReturnType.getSort() != Type.VOID) {
 				// Int tags
 				super.visitInsn(DUP);
 				loadSourceLblAndMakeTaint();

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/TaintSourceWrapper.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/TaintSourceWrapper.java
@@ -2,6 +2,8 @@ package edu.columbia.cs.psl.phosphor.runtime;
 
 import edu.columbia.cs.psl.phosphor.struct.*;
 
+import java.lang.reflect.Array;
+
 /**
  * This class handles dynamically doing source-based tainting.
  * 
@@ -72,12 +74,19 @@ public class TaintSourceWrapper<T extends AutoTaintLabel> {
 
 	/* Called by sources for the arguments and return value. Adds the specified tag to the specified object. */
 	public Object autoTaint(Object obj, String source, int argIdx, Taint<? extends AutoTaintLabel> tag) {
-		if(obj instanceof LazyArrayObjTags) {
+	    if(obj == null) {
+	        return null;
+        } else if(obj instanceof LazyArrayObjTags) {
 			return autoTaint((LazyArrayObjTags) obj, source, argIdx, tag);
 		} else if(obj instanceof TaintedWithObjTag) {
 			return autoTaint((TaintedWithObjTag) obj, source, argIdx, tag);
 		} else if(obj instanceof TaintedPrimitiveWithObjTag) {
 			return autoTaint((TaintedPrimitiveWithObjTag) obj, source, argIdx, tag);
+		} else if(obj.getClass().isArray()) {
+			for(int i = 0; i < Array.getLength(obj); i++) {
+				Array.set(obj, i, autoTaint(Array.get(obj, i), source, argIdx, tag));
+			}
+			return obj;
 		}
 		return obj;
 	}

--- a/Phosphor/src/taint-sources
+++ b/Phosphor/src/taint-sources
@@ -32,9 +32,13 @@
 #phosphor/test/SourceSinkTest.sourceRet2()[I
 #phosphor/test/SourceSinkTest.sourceRet3()Ljava/lang/Object;
 #phosphor/test/SourceSinkTest.sourceRet4()[I
+
 edu/columbia/cs/psl/test/phosphor/AutoTaintObjTagITCase.source()Ljava/lang/String;
 edu/columbia/cs/psl/test/phosphor/AutoTaintObjTagITCase.iSource()I
 edu/columbia/cs/psl/test/phosphor/AutoTaintObjTagITCase.source([I)V
 edu/columbia/cs/psl/test/phosphor/AutoTaintObjTagITCase.source([I)V
+edu/columbia/cs/psl/test/phosphor/AutoTaintObjTagITCase.sourceWithDoubleCharArrParam([[C)V
+edu/columbia/cs/psl/test/phosphor/AutoTaintObjTagITCase.sourceWithStringArrParam([Ljava/lang/String;)V
+
 edu/columbia/cs/psl/test/phosphor/InheritedAutoTaintObjTagITCase$TaintSourceInterface.getSource()I
 edu/columbia/cs/psl/test/phosphor/InheritedAutoTaintObjTagITCase$TaintSourceClass.getSource()I

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/AutoTaintObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/AutoTaintObjTagITCase.java
@@ -42,6 +42,14 @@ public class AutoTaintObjTagITCase extends BaseMultiTaintClass {
 		}
 	}
 
+	public void sourceWithDoubleCharArrParam(char[][] arr) {
+		arr[0][0] = 'b';
+	}
+
+	public void sourceWithStringArrParam(String[] arr) {
+		arr[0] = new String("hello");
+	}
+
 	/* Tests that calling a taintThrough method for an untainted object doesn't clear existing taint tags of that method's
 	 * primitive return value.
 	 */
@@ -126,6 +134,23 @@ public class AutoTaintObjTagITCase extends BaseMultiTaintClass {
 		int result = exceptionCatchingSink(5);
 		assertEquals(7, result);
 	}
+
+	/* Checks that sources properly taint multi-dimensional primitive array arguments passed to them. */
+	@Test
+	public void testSourceTaints2DCharArrArg() throws Exception {
+		char[][] chars = new char[1][1];
+		sourceWithDoubleCharArrParam(chars);
+		assertNoTaint(chars[0] + "");
+	}
+
+	/* Checks that sources properly taint object array arguments passed to them. */
+	@Test
+	public void testSourceTaintsStringArg() throws Exception {
+		String[] arr = new String[]{null, new String("Test2")};
+		sourceWithStringArrParam(arr);
+		assertNonNullTaint(arr[0]);
+	}
+
 
 	@Test(expected = TaintSinkError.class)
 	public void testIntSink() throws Exception {


### PR DESCRIPTION
… and 2+ dimensional primitive arrays) so that autoTaint is used instead of combineTaints on array. Added code to help TaintSourceWrapper.autoTaint to deal with arrays in a reasonable fashion.

* Sources now taint arguments before returning in addition to at the beginning of the method in a similar fashion to taintThrough methods.
* Added test cases that were previously failing.