### PR TITLE
Taint duplicate label fix

### DIFF
--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/Taint.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/Taint.java
@@ -10,15 +10,11 @@ import java.util.Arrays;
 public class Taint<T> implements Serializable {
 	public static boolean IGNORE_TAINTING;
 
-	public static final <T> Taint<T> copyTaint(Taint<T> in)
-	{
-		if(in == null)
-			return null;
-		return in.copy();
+	public static final <T> Taint<T> copyTaint(Taint<T> in) {
+		return in == null ? null : in.copy();
 	}
 
-	public Taint<T> copy()
-	{
+	public Taint<T> copy() {
 		if(IGNORE_TAINTING)
 			return this;
 		Taint<T> ret = new Taint<T>();
@@ -29,6 +25,7 @@ public class Taint<T> implements Serializable {
 			ret.tags = tags.clone();
 		return ret;
 	}
+
 //	public Object clone()  {
 //		try {
 //			Object ret = super.clone();
@@ -41,16 +38,13 @@ public class Taint<T> implements Serializable {
 //			return null;
 //		}
 //	}
+
 	@Override
 	public String toString() {
-		String depStr=" deps = [";
-		if(dependencies != null)
-		{
-			depStr += dependencies.toString();
-		}
-		depStr += "]";
-		return "Taint [lbl=" + lbl + " "+depStr+"]";
+		String depStr = " deps = [" + (dependencies != null ? dependencies.toString() : "") + "]";
+		return "Taint [lbl=" + lbl + " " + depStr + "]";
 	}
+
 	public transient Object debug;
 	public T lbl;
 	public SimpleHashSet<T> dependencies;
@@ -62,22 +56,21 @@ public class Taint<T> implements Serializable {
 	}
 
 	public static int TAINT_ARRAY_SIZE = -1;
+
 	public void setBit(int tag) {
 		int bits = tag % 31;
 		int key = tag / 31;
 		tags[key] |= 1 << bits;
 	}
 
-	public boolean hasBitSet(int tag)
-	{
+	public boolean hasBitSet(int tag) {
 		int bits = tag % 31;
 		int key = tag / 31;
 		return (tags[key] & (1 << bits)) != 0;
 	}
-	
-	public void setBits(int[] otherTags){
-		for(int i = 0; i < otherTags.length; i++)
-		{
+
+	public void setBits(int[] otherTags) {
+		for(int i = 0; i < otherTags.length; i++) {
 			tags[i] |= otherTags[i];
 		}
 	}
@@ -97,270 +90,250 @@ public class Taint<T> implements Serializable {
 		this.lbl = lbl;
 		dependencies = new SimpleHashSet<T>();
 	}
+
 	public T getLabel() {
 		return lbl;
-	}
-	public SimpleHashSet<T> getDependencies$$PHOSPHORTAGGED() {
-		return getDependencies();
 	}
 
 	public int[] getTags() {
 		return tags;
 	}
-	public LazyIntArrayObjTags getTags$$PHOSPHORTAGGED(){
+
+	@SuppressWarnings("unused")
+	public LazyIntArrayObjTags getTags$$PHOSPHORTAGGED() {
 		return new LazyIntArrayObjTags(tags);
 	}
-	public LazyIntArrayObjTags getTags$$PHOSPHORTAGGED(ControlTaintTagStack ctrl){
+
+	@SuppressWarnings("unused")
+	public LazyIntArrayObjTags getTags$$PHOSPHORTAGGED(ControlTaintTagStack ctrl) {
 		return new LazyIntArrayObjTags(tags);
 	}
 
 	public SimpleHashSet<T> getDependencies() {
 		return dependencies;
 	}
-	public Taint(Taint<T> t1)
-	{
-		if(t1 == null)
+
+	@SuppressWarnings("unused")
+	public SimpleHashSet<T> getDependencies$$PHOSPHORTAGGED() {
+		return getDependencies();
+	}
+
+	public Taint(Taint<T> t1) {
+		if(t1 == null) {
 			return;
+		}
 		if(t1.dependencies != null) {
 			dependencies = new SimpleHashSet<>();
 			dependencies.addAll(t1.dependencies);
 		}
-		if(t1.tags != null)
-		{
+		if(t1.tags != null) {
 			tags = new int[t1.tags.length];
 			System.arraycopy(t1.tags,0,tags,0,tags.length);
 		}
 		lbl = t1.lbl;
-		if(Configuration.derivedTaintListener != null)
+		if(Configuration.derivedTaintListener != null) {
 			Configuration.derivedTaintListener.singleDepCreated(t1, this);
+		}
 	}
-	public Taint(Taint<T> t1, Taint<T> t2)
-	{
-		if(t2 == null && t1 != null)
-		{
+
+	public Taint(Taint<T> t1, Taint<T> t2) {
+		if(t1 != null) {
 			lbl = t1.lbl;
 			if(t1.dependencies != null) {
 				dependencies = new SimpleHashSet<>();
 				dependencies.addAll(t1.dependencies);
 			}
-			if(t1.tags != null)
-			{
+			if(t1.tags != null) {
 				tags = new int[t1.tags.length];
 				System.arraycopy(t1.tags,0,tags,0,tags.length);
 			}
 		}
-		else if(t1 == null && t2 != null)
-		{
-			lbl = t2.lbl;
+		if(t2 != null) {
+			if(t2.lbl != null) {
+				lbl = lbl == null ? t2.lbl : lbl; // Set the label to be the second taints label if it was null
+				if(!lbl.equals(t2.lbl)) {
+					// Create dependencies if it does not already exist
+					dependencies = (dependencies == null) ? new SimpleHashSet<T>() : dependencies;
+					dependencies.add(t2.lbl);
+				}
+			}
 			if(t2.dependencies != null) {
-				dependencies = new SimpleHashSet<>();
+				// Create dependencies if it does not already exist
+				dependencies = (dependencies == null) ? new SimpleHashSet<T>() : dependencies;
 				dependencies.addAll(t2.dependencies);
 			}
-			if(t2.tags != null)
-			{
-				tags = new int[t2.tags.length];
-				System.arraycopy(t2.tags,0,tags,0,tags.length);
-			}
-		} else {
-			//in this case, should still set this.lbl
-			boolean lblSet = false;
-			if (t1 != null)
-			{
-				if (t1.lbl != null)
-				{
-					this.lbl = t1.lbl;
-					lblSet = true;
-				}
-				if(t1.dependencies != null) {
-					dependencies = new SimpleHashSet<>();
-					dependencies.addAll(t1.dependencies);
-				}
-				if(t1.tags != null)
-				{
-					tags = new int[t1.tags.length];
-					System.arraycopy(t1.tags,0,tags,0,tags.length);
-				}
-			}
-			if (t2 != null) {
-				if (t2.lbl != null)
-				{
-					if(lblSet)
-						dependencies.add(t2.lbl);
-					else
-						this.lbl = t2.lbl;
-				}
-				if(t2.dependencies != null) {
-					dependencies = new SimpleHashSet<>();
-					dependencies.addAll(t2.dependencies);
-				}
-				if(t2.tags != null)
-				{
-					if(tags == null) {
-						tags = new int[t2.tags.length];
-						System.arraycopy(t2.tags, 0, tags, 0, tags.length);
-					}
-					else{
-						setBits(t2.tags);
-					}
+			if(t2.tags != null) {
+				if(tags == null) {
+					tags = new int[t2.tags.length];
+					System.arraycopy(t2.tags, 0, tags, 0, tags.length);
+				} else {
+					setBits(t2.tags);
 				}
 			}
 		}
-		if(Configuration.derivedTaintListener != null)
+		// Make sure that lbl is not also in the dependencies
+		if(lbl != null && dependencies != null) {
+			dependencies.remove(lbl);
+		}
+		if(Configuration.derivedTaintListener != null) {
 			Configuration.derivedTaintListener.doubleDepCreated(t1, t2, this);
+		}
 	}
+
 	public Taint() {
 		if(TAINT_ARRAY_SIZE > 0)
 			tags = new int[TAINT_ARRAY_SIZE];
 	}
-	public boolean addDependency(Taint<T> d)
-	{
-		if(d == null)
+
+	public boolean addDependency(Taint<T> d) {
+		if(d == null) {
 			return false;
-		if(d.dependencies == null && d.lbl == null && Taint.TAINT_ARRAY_SIZE > 0)
-		{
-			//accumulate tags
-			if(d.tags == null)
+		}
+		if(d.dependencies == null && d.lbl == null && Taint.TAINT_ARRAY_SIZE > 0) {
+			// accumulate tags
+			if(d.tags == null) {
 				return false;
-			if(this.tags == null)
-				this.tags = new int[Taint.TAINT_ARRAY_SIZE];
+			}
+			// Create tags if it does not already exist
+			tags = (tags == null) ? new int[Taint.TAINT_ARRAY_SIZE] : tags;
 			return setBitsIfNeeded(d.tags);
 		}
-		if(dependencies == null)
-			dependencies = new SimpleHashSet<>();
+		// Create dependencies if it does not already exist
+		dependencies = (dependencies == null) ? new SimpleHashSet<T>() : dependencies;
 		boolean added = false;
-		if(d.hasNoDependencies())
-		{
-			if(this.lbl == d.lbl)
-				return false;
-			return dependencies.add(d.lbl);
-		}
-		if(d.lbl != null && d.lbl != this.lbl)
+		if(d.lbl != null && !d.lbl.equals(lbl)) {
 			added = dependencies.add(d.lbl);
-		added |= dependencies.addAll(d.dependencies);
+		}
+		if(!d.hasNoDependencies()) {
+			added |= dependencies.addAll(d.dependencies);
+		}
 		return added;
 	}
-	public TaintedBooleanWithObjTag hasNoDependencies$$PHOSPHORTAGGED(ControlTaintTagStack ctrl, TaintedBooleanWithObjTag ret)
-	{
-		ret.val = hasNoDependencies();
-		ret.taint = null;
-		return ret;
-	}
-	public TaintedBooleanWithObjTag hasNoDependencies$$PHOSPHORTAGGED(TaintedBooleanWithObjTag ret)
-	{
-		ret.val = hasNoDependencies();
-		ret.taint = null;
-		return ret;
-	}
+
 	public boolean hasNoDependencies() {
-		if (dependencies == null)
-			if (tags == null)
-				return true;
-			else
-				return isEmpty(tags);
-		return dependencies.isEmpty();
+		return (dependencies == null || dependencies.isEmpty()) && (tags == null || isEmpty(tags));
+	}
+
+	@SuppressWarnings("unused")
+	public TaintedBooleanWithObjTag hasNoDependencies$$PHOSPHORTAGGED(TaintedBooleanWithObjTag ret) {
+		ret.val = hasNoDependencies();
+		ret.taint = null;
+		return ret;
+	}
+
+	@SuppressWarnings("unused")
+	public TaintedBooleanWithObjTag hasNoDependencies$$PHOSPHORTAGGED(ControlTaintTagStack ctrl, TaintedBooleanWithObjTag ret) {
+		ret.val = hasNoDependencies();
+		ret.taint = null;
+		return ret;
 	}
 
 	private boolean isEmpty(int[] tags) {
-		for (int i : tags)
-			if (i != 0)
+		for(int i : tags) {
+			if (i != 0) {
 				return false;
+			}
+		}
+
 		return true;
 	}
 
-	public static <T> void combineTagsOnArrayInPlace(Object[] ar, Taint<T>[] t1, int dims)
-	{
+	public static <T> void combineTagsOnArrayInPlace(Object[] ar, Taint<T>[] t1, int dims) {
 		combineTagsInPlace(ar, t1[dims-1]);
-		if(dims == 1)
-		{
-			for(Object  o : ar)
-			{
+		if(dims == 1) {
+			for(Object o : ar) {
 				combineTagsInPlace(o, t1[dims-1]);
 			}
 		}
-		else
-		{
-			for(Object o : ar)
+		else {
+			for(Object o : ar) {
 				combineTagsOnArrayInPlace((Object[]) o, t1, dims-1);
+			}
 		}
-	}
-	public static <T> void combineTagsInPlace(Object obj, Taint<T> t1) {
-		if (obj == null || t1 == null || IGNORE_TAINTING)
-			return;
-		_combineTagsInPlace(obj, t1);
-	}
-	public static <T> void _combineTagsInPlace(Object obj, Taint<T> t1){
-		@SuppressWarnings("unchecked")
-		Taint<T> t = (Taint<T>) TaintUtils.getTaintObj(obj);
-		if(t == null)
-		{
-			MultiTainter.taintedObject(obj, new Taint(t1));
-		}
-		else
-			t.addDependency(t1);
-	}
-	public static <T> Taint<T> combineTags(Taint<T> t1, Taint<T> t2)
-	{
-		if(t1 == null && t2 == null)
-			return null;
-		if(t2 == null)
-			return t1;
-		if(t1 == null)
-			return t2;
-		if(t1 == t2)
-			return t1;
-		if(t1.lbl == null && t1.hasNoDependencies())
-			return t2;
-		if(t2.lbl == null && t2.hasNoDependencies())
-			return t1;
-		if(IGNORE_TAINTING)
-			return t1;
-		if(t1.equals(t2))
-			return t1;
-		if(t1.contains(t2))
-			return t1;
-		if(t2.contains(t1))
-			return t2;
-		Taint<T> r = new Taint<T>(t1,t2);
-		if(Configuration.derivedTaintListener != null)
-			Configuration.derivedTaintListener.doubleDepCreated(t1, t2, r);
-		return r;
 	}
 
-	public TaintedBooleanWithObjTag contains$$PHOSPHORTAGGED(Taint<T> that, TaintedBooleanWithObjTag ret, ControlTaintTagStack ctrl){
+	public static <T> void combineTagsInPlace(Object obj, Taint<T> t1) {
+		if(obj == null || t1 == null || IGNORE_TAINTING) {
+			return;
+		}
+		_combineTagsInPlace(obj, t1);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> void _combineTagsInPlace(Object obj, Taint<T> t1) {
+		Taint<T> t = (Taint<T>) TaintUtils.getTaintObj(obj);
+		if(t == null) {
+			MultiTainter.taintedObject(obj, new Taint(t1));
+		}
+		else {
+			t.addDependency(t1);
+		}
+	}
+
+	public static <T> Taint<T> combineTags(Taint<T> t1, Taint<T> t2) {
+		if(t1 == null && t2 == null) {
+			return null;
+		} else if(t2 == null || (t2.lbl == null && t2.hasNoDependencies())) {
+			return t1;
+		} else if(t1 == null || (t1.lbl == null && t1.hasNoDependencies())) {
+			return t2;
+		} else if(t1.equals(t2) || IGNORE_TAINTING) {
+			return t1;
+		} else if(t1.contains(t2)) {
+			return t1;
+		} else if(t2.contains(t1)) {
+			return t2;
+		} else {
+			Taint<T> r = new Taint<T>(t1,t2);
+			if(Configuration.derivedTaintListener != null) {
+				Configuration.derivedTaintListener.doubleDepCreated(t1, t2, r);
+			}
+			return r;
+		}
+	}
+
+	public boolean contains(Taint<T> that) {
+		if(that == null) {
+			return true;
+		}
+		if(that.tags != null) {
+			for(int i = 0; i < that.tags.length; i++) {
+				if((tags[i] | that.tags[i]) != tags[i]) {
+					return false;
+				}
+			}
+			return true;
+		}
+		if(that.lbl != null && (lbl == null || !lbl.equals(that.lbl)) && !dependencies.contains(that.lbl)) {
+			return false;
+		}
+		for(T obj : that.dependencies) {
+			if((lbl == null || !lbl.equals(obj)) && !dependencies.contains(obj)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@SuppressWarnings("unused")
+	public TaintedBooleanWithObjTag contains$$PHOSPHORTAGGED(Taint<T> that, TaintedBooleanWithObjTag ret) {
 		ret.taint = null;
 		ret.val = contains(that);
 		return ret;
 	}
-	public TaintedBooleanWithObjTag contains$$PHOSPHORTAGGED(Taint<T> that, TaintedBooleanWithObjTag ret){
-		ret.taint = null;
-		ret.val = contains(that);
-		return ret;
-	}
-	public TaintedBooleanWithIntTag contains$$PHOSPHORTAGGED(Taint<T> that, TaintedBooleanWithIntTag ret){
+
+	@SuppressWarnings("unused")
+	public TaintedBooleanWithIntTag contains$$PHOSPHORTAGGED(Taint<T> that, TaintedBooleanWithIntTag ret) {
 		ret.taint = 0;
 		ret.val = contains(that);
 		return ret;
 	}
-	public boolean contains(Taint<T> that) {
-		boolean lblFound = false;
-		if(that.tags != null){
-			for(int i = 0; i < that.tags.length; i++)
-			{
-				if((tags[i] | that.tags[i]) != tags[i])
-					return false;
-			}
-			return true;
-		}
-		if (this.lbl == that.lbl)
-			lblFound = true;
-		if (!lblFound)
-			if (!this.dependencies.contains(that.lbl))
-				return false;
-		for (T obj : that.dependencies) {
-			if (!(this.dependencies.contains(obj) || this.lbl == obj))
-				return false;
-		}
-		return true;
+
+	@SuppressWarnings("unused")
+	public TaintedBooleanWithObjTag contains$$PHOSPHORTAGGED(Taint<T> that, TaintedBooleanWithObjTag ret, ControlTaintTagStack ctrl) {
+		ret.taint = null;
+		ret.val = contains(that);
+		return ret;
 	}
 
 	@Override
@@ -385,12 +358,14 @@ public class Taint<T> implements Serializable {
 		return result;
 	}
 
-	public static <T> Taint<T> _combineTagsInternal(Taint<T> t1, ControlTaintTagStack tags){
-		if(t1 == null && tags.taint == null && (!Configuration.IMPLICIT_EXCEPTION_FLOW || (tags.influenceExceptions == null || tags.influenceExceptions.isEmpty())))
+	@SuppressWarnings("unchecked")
+	public static <T> Taint<T> _combineTagsInternal(Taint<T> t1, ControlTaintTagStack tags) {
+		if(t1 == null && tags.taint == null && (!Configuration.IMPLICIT_EXCEPTION_FLOW || (tags.influenceExceptions == null || tags.influenceExceptions.isEmpty()))) {
 			return null;
+		}
 		Taint tagsTaint;
 		if(Configuration.IMPLICIT_EXCEPTION_FLOW) {
-			if((tags.influenceExceptions == null || tags.influenceExceptions.isEmpty())){
+			if((tags.influenceExceptions == null || tags.influenceExceptions.isEmpty())) {
 				//Can do a direct check of taint subsumption, no exception data to look at
 				if(tags.getTag() == null)
 					return t1;
@@ -402,50 +377,46 @@ public class Taint<T> implements Serializable {
 					return tags.copyTag();
 			}
 			tagsTaint = tags.copyTagExceptions();
-		}
-		else
+		} else {
 			tagsTaint = tags.copyTag();
-		if(t1 == null || (t1.lbl == null && t1.hasNoDependencies()))
-		{
+		}
+		if(t1 == null || (t1.lbl == null && t1.hasNoDependencies())) {
 //			if(tags.isEmpty())
 //				return null;
 			return tagsTaint;
-		}
-		else if(tagsTaint == null || (tagsTaint.lbl == null && tagsTaint.hasNoDependencies()))
-		{
+		} else if(tagsTaint == null || (tagsTaint.lbl == null && tagsTaint.hasNoDependencies())) {
 //			if(t1.lbl == null && t1.hasNoDependencies())
 //				return null;
 			return t1;
+		} else if(t1 == tagsTaint) {
+			return t1;
 		}
-		else if(t1 == tagsTaint)
+		if(IGNORE_TAINTING) {
 			return t1;
-		if(IGNORE_TAINTING)
-			return t1;
+		}
 		tagsTaint.addDependency(t1);
 		return tagsTaint;
 	}
-	@SuppressWarnings("unchecked")
-	public static <T> Taint<T> combineTags(Taint<T> t1, ControlTaintTagStack tags){
-		if(t1 == null && tags.taint == null && (tags.influenceExceptions == null || tags.influenceExceptions.isEmpty()))
+
+	public static <T> Taint<T> combineTags(Taint<T> t1, ControlTaintTagStack tags) {
+		if(t1 == null && tags.taint == null && (tags.influenceExceptions == null || tags.influenceExceptions.isEmpty())) {
 			return null;
+		}
 		return _combineTagsInternal(t1,tags);
 	}
+
 	@SuppressWarnings("rawtypes")
-	public static void combineTagsOnObject(Object o, ControlTaintTagStack tags)
-	{
-		if((tags.isEmpty() || IGNORE_TAINTING) && (!Configuration.IMPLICIT_EXCEPTION_FLOW || (tags.influenceExceptions == null || tags.influenceExceptions.isEmpty())))
+	public static void combineTagsOnObject(Object o, ControlTaintTagStack tags) {
+		if((tags.isEmpty() || IGNORE_TAINTING) && (!Configuration.IMPLICIT_EXCEPTION_FLOW || (tags.influenceExceptions == null || tags.influenceExceptions.isEmpty()))) {
 			return;
-		if(Configuration.derivedTaintListener != null)
+		}
+		if(Configuration.derivedTaintListener != null) {
 			Configuration.derivedTaintListener.controlApplied(o, tags);
-		if(o instanceof TaintedWithObjTag)
-		{
-			if(o instanceof String)
-			{
-				combineTagsOnString((String) o, tags);
-			}
-			else
-				((TaintedWithObjTag) o).setPHOSPHOR_TAG(Taint.combineTags((Taint) ((TaintedWithObjTag)o).getPHOSPHOR_TAG(), tags));
-	
+		}
+		if(o instanceof  String) {
+			combineTagsOnString((String) o, tags);
+		} else if(o instanceof TaintedWithObjTag) {
+			((TaintedWithObjTag) o).setPHOSPHOR_TAG(Taint.combineTags((Taint) ((TaintedWithObjTag)o).getPHOSPHOR_TAG(), tags));
 		}
 	}
 

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/Taint.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/Taint.java
@@ -413,7 +413,7 @@ public class Taint<T> implements Serializable {
 		if(Configuration.derivedTaintListener != null) {
 			Configuration.derivedTaintListener.controlApplied(o, tags);
 		}
-		if(o instanceof  String) {
+		if(o instanceof String) {
 			combineTagsOnString((String) o, tags);
 		} else if(o instanceof TaintedWithObjTag) {
 			((TaintedWithObjTag) o).setPHOSPHOR_TAG(Taint.combineTags((Taint) ((TaintedWithObjTag)o).getPHOSPHOR_TAG(), tags));


### PR DESCRIPTION
Fixed issue where a Taint's lbl could be added to its dependencies. Switched various tests for label equivalence from using == to using equals method. Standardized brackets and spacing. Minor refactoring.