### PR TITLE
Make the Taint class immutable

### DIFF
--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/TaintUtils.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/TaintUtils.java
@@ -331,10 +331,10 @@ public class TaintUtils {
 		} else if (ArrayHelper.engaged == 1) {
 			return ArrayHelper.getTag(obj);
 		} else if (obj instanceof Taint[]) {
-			Taint ret = new Taint();
+			Taint ret = Taint.createTaint();
 			for (Taint t : ((Taint[]) obj)) {
 				if (t != null)
-					ret.addDependency(t);
+					ret = Taint.addDependency(ret, t);
 			}
 			if (ret.hasNoDependencies())
 				return null;
@@ -463,7 +463,7 @@ public class TaintUtils {
 					if (taints[i] == null)
 						taints[i] = ctrl.copyTag();
 					else
-						taints[i].addDependency(ctrl.getTag());
+						taints[i] = Taint.addDependency(taints[i], ctrl.getTag());
 				}
 			}
 		} else if (!dest.getClass().isArray()) {
@@ -542,12 +542,12 @@ public class TaintUtils {
 			Taint t = null;
 			if (srcPosTaint != null) {
 				t = ((Taint) srcPosTaint).copy();
-				t.addDependency((Taint) destPosTaint);
-				t.addDependency((Taint) lengthTaint);
+				t = Taint.addDependency(t, (Taint) destPosTaint);
+				t = Taint.addDependency(t, (Taint) lengthTaint);
 			} else if (destPosTaint != null) {
 
 				t = ((Taint) destPosTaint).copy();
-				t.addDependency((Taint) lengthTaint);
+				t = Taint.addDependency(t, (Taint) lengthTaint);
 			} else if (lengthTaint != null) {
 
 				t = ((Taint) lengthTaint).copy();
@@ -574,7 +574,7 @@ public class TaintUtils {
 					if (taints[i] == null)
 						taints[i] = ctrl.copyTag();
 					else {
-						taints[i].addDependency(ctrl.getTag());
+						taints[i] = Taint.addDependency(taints[i], ctrl.getTag());
 					}
 				}
 			}
@@ -582,12 +582,12 @@ public class TaintUtils {
 			Taint t = null;
 			if (srcPosTaint != null) {
 				t = ((Taint) srcPosTaint).copy();
-				t.addDependency((Taint) destPosTaint);
-				t.addDependency((Taint) lengthTaint);
+				t = Taint.addDependency(t, (Taint) destPosTaint);
+				t = Taint.addDependency(t, (Taint) lengthTaint);
 			} else if (destPosTaint != null) {
 
 				t = ((Taint) destPosTaint).copy();
-				t.addDependency((Taint) lengthTaint);
+				t = Taint.addDependency(t, (Taint) lengthTaint);
 			} else if (lengthTaint != null) {
 
 				t = ((Taint) lengthTaint).copy();

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/TaintUtils.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/TaintUtils.java
@@ -324,7 +324,7 @@ public class TaintUtils {
 	}
 
 	public static Taint getTaintObj(Object obj) {
-		if (obj == null || Taint.IGNORE_TAINTING)
+		if (obj == null || Taint.isIgnoreTainting())
 			return null;
 		if (obj instanceof TaintedWithObjTag) {
 			return (Taint) ((TaintedWithObjTag) obj).getPHOSPHOR_TAG();
@@ -986,7 +986,7 @@ public class TaintUtils {
 		T ret = Enum.valueOf(enumType, name);
 		Taint tag = (Taint) ((TaintedWithObjTag) ((Object) name)).getPHOSPHOR_TAG();
 		tag = Taint.combineTags(tag, ctrl);
-		if (tag != null && !(tag.getLabel() == null && tag.hasNoDependencies())) {
+		if (tag != null && !(tag.getLbl() == null && tag.hasNoDependencies())) {
 			ret = shallowClone(ret);
 			((TaintedWithObjTag) ret).setPHOSPHOR_TAG(tag);
 		}

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/DataAndControlFlowTagFactory.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/DataAndControlFlowTagFactory.java
@@ -12,7 +12,7 @@ public class DataAndControlFlowTagFactory implements TaintTagFactory, Opcodes {
 
 	@Override
 	public Taint<?> getAutoTaint(String source) {
-		return new Taint(source);
+		return Taint.createTaint(source);
 	}
 	@Override
 	public void methodOp(int opcode, String owner, String name, String desc, boolean itfc, MethodVisitor mv, LocalVariableManager lvs, TaintPassingMV ta) {

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/CharacterUtils.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/CharacterUtils.java
@@ -77,7 +77,7 @@ public class CharacterUtils {
 				ret.taint = tags.taints[i];
 			return ret;
 		} catch (StringIndexOutOfBoundsException ex) {
-			Taint _t = new Taint(t);
+			Taint _t = Taint.createTaint(t);
 			((TaintedWithObjTag) ex).setPHOSPHOR_TAG(_t);
 			throw ex;
 		}
@@ -90,8 +90,8 @@ public class CharacterUtils {
 				ret.taint = ((String) seq).valuePHOSPHOR_TAG.taints[i];
 			return ret;
 		} catch (StringIndexOutOfBoundsException ex) {
-			Taint _t = new Taint(t);
-			_t.addDependency((Taint) ((TaintedWithObjTag) seq).getPHOSPHOR_TAG());
+			Taint _t = Taint.createTaint(t);
+			_t = Taint.addDependency(_t, (Taint) ((TaintedWithObjTag) seq).getPHOSPHOR_TAG());
 			((TaintedWithObjTag) ex).setPHOSPHOR_TAG(_t);
 			throw ex;
 		}
@@ -105,7 +105,7 @@ public class CharacterUtils {
 				ret.taint = tags.taints[i];
 			return ret;
 		} catch (StringIndexOutOfBoundsException ex) {
-			Taint _t = new Taint(t);
+			Taint _t = Taint.createTaint(t);
 			((TaintedWithObjTag) ex).setPHOSPHOR_TAG(_t);
 			throw ex;
 		}
@@ -120,7 +120,7 @@ public class CharacterUtils {
 				ret.taint = tags.taints[i];
 			return ret;
 		} catch (StringIndexOutOfBoundsException ex) {
-			Taint _t = new Taint(t);
+			Taint _t = Taint.createTaint(t);
 			((TaintedWithObjTag) ex).setPHOSPHOR_TAG(_t);
 			throw ex;
 		}
@@ -133,8 +133,8 @@ public class CharacterUtils {
 				ret.taint = ((String) seq).valuePHOSPHOR_TAG.taints[i];
 			return ret;
 		} catch (StringIndexOutOfBoundsException ex) {
-			Taint _t = new Taint(t);
-			_t.addDependency((Taint) ((TaintedWithObjTag) seq).getPHOSPHOR_TAG());
+			Taint _t = Taint.createTaint(t);
+			_t = Taint.addDependency(_t, (Taint) ((TaintedWithObjTag) seq).getPHOSPHOR_TAG());
 			((TaintedWithObjTag) ex).setPHOSPHOR_TAG(_t);
 			throw ex;
 		}
@@ -148,7 +148,7 @@ public class CharacterUtils {
 				ret.taint = tags.taints[i];
 			return ret;
 		} catch (StringIndexOutOfBoundsException ex) {
-			Taint _t = new Taint(t);
+			Taint _t = Taint.createTaint(t);
 			((TaintedWithObjTag) ex).setPHOSPHOR_TAG(_t);
 			throw ex;
 		}
@@ -187,8 +187,8 @@ public class CharacterUtils {
 				ret.taint = tags.taints[i];
 			return ret;
 		} catch (StringIndexOutOfBoundsException ex) {
-			Taint _t = new Taint(t);
-			_t.addDependency(ctrl.taint);
+			Taint _t = Taint.createTaint(t);
+			_t = Taint.addDependency(_t, ctrl.taint);
 			((TaintedWithObjTag) ex).setPHOSPHOR_TAG(_t);
 			throw ex;
 		}
@@ -201,9 +201,9 @@ public class CharacterUtils {
 				ret.taint = seq.toString().valuePHOSPHOR_TAG.taints[i];
 			return ret;
 		} catch (StringIndexOutOfBoundsException ex) {
-			Taint _t = new Taint(t);
-			_t.addDependency((Taint) ((TaintedWithObjTag) seq).getPHOSPHOR_TAG());
-			_t.addDependency(ctrl.taint);
+			Taint _t = Taint.createTaint(t);
+			_t = Taint.addDependency(_t, (Taint) ((TaintedWithObjTag) seq).getPHOSPHOR_TAG());
+			_t = Taint.addDependency(_t, ctrl.taint);
 			((TaintedWithObjTag) ex).setPHOSPHOR_TAG(_t);
 			throw ex;
 		}
@@ -217,8 +217,8 @@ public class CharacterUtils {
 				ret.taint = tags.taints[i];
 			return ret;
 		} catch (StringIndexOutOfBoundsException ex) {
-			Taint _t = new Taint(t);
-			_t.addDependency(ctrl.taint);
+			Taint _t = Taint.createTaint(t);
+			_t = Taint.addDependency(_t, ctrl.taint);
 			((TaintedWithObjTag) ex).setPHOSPHOR_TAG(_t);
 			throw ex;
 		}

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/MultiTainter.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/MultiTainter.java
@@ -145,49 +145,49 @@ public final class MultiTainter {
 	
 	public static TaintedBooleanWithObjTag taintedBoolean$$PHOSPHORTAGGED(Taint oldTag, boolean in, Object lbl, TaintedBooleanWithObjTag ret)
 	{
-		ret.taint = new Taint(lbl);
+		ret.taint = Taint.createTaint(lbl);
 		ret.val = in;
 		return ret;
 	}
 	public static TaintedByteWithObjTag taintedByte$$PHOSPHORTAGGED(Taint oldTag, byte in, Object lbl, TaintedByteWithObjTag ret)
 	{
-		ret.taint = new Taint(lbl);
+		ret.taint = Taint.createTaint(lbl);
 		ret.val = in;
 		return ret;
 	}
 	public static TaintedCharWithObjTag taintedChar$$PHOSPHORTAGGED(Taint oldTag, char in, Object lbl, TaintedCharWithObjTag ret)
 	{
-		ret.taint = new Taint(lbl);
+		ret.taint = Taint.createTaint(lbl);
 		ret.val = in;
 		return ret;
 	}
 	public static TaintedDoubleWithObjTag taintedDouble$$PHOSPHORTAGGED(Taint oldTag, double in, Object lbl, TaintedDoubleWithObjTag ret)
 	{
-		ret.taint = new Taint(lbl);
+		ret.taint = Taint.createTaint(lbl);
 		ret.val = in;
 		return ret;
 	}
 	public static TaintedFloatWithObjTag taintedFloat$$PHOSPHORTAGGED(Taint oldTag, float in, Object lbl, TaintedFloatWithObjTag ret)
 	{
-		ret.taint = new Taint(lbl);
+		ret.taint = Taint.createTaint(lbl);
 		ret.val = in;
 		return ret;
 	}
 	public static TaintedIntWithObjTag taintedInt$$PHOSPHORTAGGED(Taint oldTag, int in, Object lbl, TaintedIntWithObjTag ret)
 	{
-		ret.taint = new Taint(lbl);
+		ret.taint = Taint.createTaint(lbl);
 		ret.val = in;
 		return ret;
 	}
 	public static TaintedLongWithObjTag taintedLong$$PHOSPHORTAGGED(Taint oldTag, long in, Object lbl, TaintedLongWithObjTag ret)
 	{
-		ret.taint = new Taint(lbl);
+		ret.taint = Taint.createTaint(lbl);
 		ret.val = in;
 		return ret;
 	}
 	public static TaintedShortWithObjTag taintedShort$$PHOSPHORTAGGED(Taint oldTag, short in, Object lbl, TaintedShortWithObjTag ret)
 	{
-		ret.taint = new Taint(lbl);
+		ret.taint = Taint.createTaint(lbl);
 		ret.val = in;
 		return ret;
 	}
@@ -196,7 +196,7 @@ public final class MultiTainter {
 		if(ret.taints == null)
 			ret.taints = new Taint[in.length];
 		for(int i =0 ; i < in.length; i++)
-			ret.taints[i] = new Taint(lbl);
+			ret.taints[i] = Taint.createTaint(lbl);
 		return ret;
 	}
 	public static LazyByteArrayObjTags taintedByteArray$$PHOSPHORTAGGED(LazyByteArrayObjTags ret, byte[] in, Object lbl)
@@ -204,7 +204,7 @@ public final class MultiTainter {
 		if(ret.taints == null)
 			ret.taints = new Taint[in.length];
 		for(int i =0 ; i < in.length; i++)
-			ret.taints[i] = new Taint(lbl);
+			ret.taints[i] = Taint.createTaint(lbl);
 		return ret;
 	}
 	public static LazyCharArrayObjTags taintedCharArray$$PHOSPHORTAGGED(LazyCharArrayObjTags ret, char[] in, Object lbl)
@@ -212,7 +212,7 @@ public final class MultiTainter {
 		if(ret.taints == null)
 			ret.taints = new Taint[in.length];
 		for(int i =0 ; i < in.length; i++)
-			ret.taints[i] = new Taint(lbl);
+			ret.taints[i] = Taint.createTaint(lbl);
 		return ret;
 	}
 	public static LazyDoubleArrayObjTags taintedDoubleArray$$PHOSPHORTAGGED(LazyDoubleArrayObjTags ret, double[] in, Object lbl)
@@ -220,7 +220,7 @@ public final class MultiTainter {
 		if(ret.taints == null)
 			ret.taints = new Taint[in.length];
 		for(int i =0 ; i < in.length; i++)
-			ret.taints[i] = new Taint(lbl);
+			ret.taints[i] = Taint.createTaint(lbl);
 		return ret;
 	}
 	public static LazyFloatArrayObjTags taintedFloatArray$$PHOSPHORTAGGED(LazyFloatArrayObjTags ret, float[] in, Object lbl)
@@ -228,7 +228,7 @@ public final class MultiTainter {
 		if(ret.taints == null)
 			ret.taints = new Taint[in.length];
 		for(int i =0 ; i < in.length; i++)
-			ret.taints[i] = new Taint(lbl);
+			ret.taints[i] = Taint.createTaint(lbl);
 		return ret;
 	}
 	public static LazyIntArrayObjTags taintedIntArray$$PHOSPHORTAGGED(LazyIntArrayObjTags ret, int[] in, Object lbl)
@@ -236,7 +236,7 @@ public final class MultiTainter {
 		if(ret.taints == null)
 			ret.taints = new Taint[in.length];
 		for(int i =0 ; i < in.length; i++)
-			ret.taints[i] = new Taint(lbl);
+			ret.taints[i] = Taint.createTaint(lbl);
 		return ret;
 	}
 	public static LazyShortArrayObjTags taintedShortArray$$PHOSPHORTAGGED(LazyShortArrayObjTags ret, short[] in, Object lbl)
@@ -244,7 +244,7 @@ public final class MultiTainter {
 		if(ret.taints == null)
 			ret.taints = new Taint[in.length];
 		for(int i =0 ; i < in.length; i++)
-			ret.taints[i] = new Taint(lbl);
+			ret.taints[i] = Taint.createTaint(lbl);
 		return ret;
 	}
 	public static LazyLongArrayObjTags taintedLongArray$$PHOSPHORTAGGED(LazyLongArrayObjTags ret, long[] in, Object lbl)
@@ -252,7 +252,7 @@ public final class MultiTainter {
 		if(ret.taints == null)
 			ret.taints = new Taint[in.length];
 		for(int i =0 ; i < in.length; i++)
-			ret.taints[i] = new Taint(lbl);
+			ret.taints[i] = Taint.createTaint(lbl);
 		return ret;
 	}
 	public static Taint getTaint$$PHOSPHORTAGGED(Object obj)

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/RuntimeBoxUnboxPropogator.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/RuntimeBoxUnboxPropogator.java
@@ -673,7 +673,7 @@ public class RuntimeBoxUnboxPropogator {
 					if(ret.taint == null)
 						ret.taint = t.copy();
 					else
-						ret.taint.addDependency(t);
+						ret.taint = Taint.addDependency(ret.taint, t);
 			} else if (t != null)
 				ret.taint = t.copy();
 			else
@@ -703,7 +703,7 @@ public class RuntimeBoxUnboxPropogator {
 					if(ret.taint == null)
 						ret.taint = t.copy();
 					else
-						ret.taint.addDependency(t);
+						ret.taint = Taint.addDependency(ret.taint, t);
 			}
 			else if(t != null)
 				ret.taint = t.copy();
@@ -734,7 +734,7 @@ public class RuntimeBoxUnboxPropogator {
 					if(ret.taint == null)
 						ret.taint = t.copy();
 					else
-						ret.taint.addDependency(t);
+						ret.taint = Taint.addDependency(ret.taint, t);
 			} else if (t != null)
 				ret.taint = t.copy();
 			else
@@ -764,7 +764,7 @@ public class RuntimeBoxUnboxPropogator {
 					if(ret.taint == null)
 						ret.taint = t.copy();
 					else
-						ret.taint.addDependency(t);
+						ret.taint = Taint.addDependency(ret.taint, t);
 			} else if (t != null)
 				ret.taint = t.copy();
 			else
@@ -812,7 +812,7 @@ public class RuntimeBoxUnboxPropogator {
 					if(ret.taint == null)
 						ret.taint = t.copy();
 					else
-						ret.taint.addDependency(t);
+						ret.taint = Taint.addDependency(ret.taint, t);
 			} else if (t != null)
 				ret.taint = t.copy();
 			else
@@ -869,7 +869,7 @@ public class RuntimeBoxUnboxPropogator {
 					if(ret.taint == null)
 						ret.taint = t.copy();
 					else
-						ret.taint.addDependency(t);
+						ret.taint = Taint.addDependency(ret.taint, t);
 			}
 			else if(t != null)
 				ret.taint = t.copy();
@@ -900,7 +900,7 @@ public class RuntimeBoxUnboxPropogator {
 					if(ret.taint == null)
 						ret.taint = t.copy();
 					else
-						ret.taint.addDependency(t);
+						ret.taint = Taint.addDependency(ret.taint, t);
 			}
 			else if(t != null)
 				ret.taint = t.copy();
@@ -931,7 +931,7 @@ public class RuntimeBoxUnboxPropogator {
 					if(ret.taint == null)
 						ret.taint = t.copy();
 					else
-						ret.taint.addDependency(t);
+						ret.taint = Taint.addDependency(ret.taint, t);
 			}
 			else if(t != null)
 				ret.taint = t.copy();
@@ -962,7 +962,7 @@ public class RuntimeBoxUnboxPropogator {
 					if(ret.taint == null)
 						ret.taint = t.copy();
 					else
-						ret.taint.addDependency(t);
+						ret.taint = Taint.addDependency(ret.taint, t);
 			}
 			else if(t != null)
 				ret.taint = t.copy();
@@ -993,7 +993,7 @@ public class RuntimeBoxUnboxPropogator {
 					if(ret.taint == null)
 						ret.taint = t.copy();
 					else
-						ret.taint.addDependency(t);
+						ret.taint = Taint.addDependency(ret.taint, t);
 			}
 			else if(t != null)
 				ret.taint = t.copy();
@@ -1024,7 +1024,7 @@ public class RuntimeBoxUnboxPropogator {
 					if(ret.taint == null)
 						ret.taint = t.copy();
 					else
-						ret.taint.addDependency(t);
+						ret.taint = Taint.addDependency(ret.taint, t);
 			} else if (t != null)
 				ret.taint = t.copy();
 			else

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/Taint.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/Taint.java
@@ -17,43 +17,9 @@ public final class Taint<T> implements Serializable {
 	private SimpleHashSet<T> dependencies;
 	private int[] tags;
 
-	public static boolean isIgnoreTainting() {
-		return IGNORE_TAINTING;
-	}
-
-	public static final <T> Taint<T> copyTaint(Taint<T> in) {
-		return in == null ? null : in.copy();
-	}
-
-	public Taint<T> copy() {
-		if(IGNORE_TAINTING)
-			return this;
-		Taint<T> ret = new Taint<T>();
-		ret.lbl = lbl;
-		if(dependencies != null)
-			ret.dependencies = dependencies.copy();
-		if(tags != null)
-			ret.tags = tags.clone();
-		return ret;
-	}
-
-//	public Object clone()  {
-//		try {
-//			Object ret = super.clone();
-//			Taint r = (Taint) ret;
-//			r.dependencies = (LinkedList<Taint>) dependencies.clone();
-//			return ret;
-//		} catch (CloneNotSupportedException e) {
-//			e.printStackTrace();
-//
-//			return null;
-//		}
-//	}
-
-	@Override
-	public String toString() {
-		String depStr = " deps = [" + (dependencies != null ? dependencies.toString() : "") + "]";
-		return "Taint [lbl=" + lbl + " " + depStr + "]";
+	public Taint() {
+		if(TAINT_ARRAY_SIZE > 0)
+			tags = new int[TAINT_ARRAY_SIZE];
 	}
 
 	public Taint(int startingTag) {
@@ -61,65 +27,9 @@ public final class Taint<T> implements Serializable {
 		setBit(startingTag);
 	}
 
-	public void setBit(int tag) {
-		int bits = tag % 31;
-		int key = tag / 31;
-		tags[key] |= 1 << bits;
-	}
-
-	public boolean hasBitSet(int tag) {
-		int bits = tag % 31;
-		int key = tag / 31;
-		return (tags[key] & (1 << bits)) != 0;
-	}
-
-	public void setBits(int[] otherTags) {
-		for(int i = 0; i < otherTags.length; i++) {
-			tags[i] |= otherTags[i];
-		}
-	}
-
-	private boolean setBitsIfNeeded(int[] otherTags) {
-		boolean changed = false;
-		for (int i = 0; i < otherTags.length; i++) {
-			if ((tags[i] | otherTags[i]) != tags[i]) {
-				tags[i] |= otherTags[i];
-				changed = true;
-			}
-		}
-		return changed;
-	}
-
 	public Taint(T lbl) {
 		this.lbl = lbl;
 		dependencies = new SimpleHashSet<T>();
-	}
-
-	public T getLbl() {
-		return lbl;
-	}
-
-	public int[] getTags() {
-		return tags;
-	}
-
-	@SuppressWarnings("unused")
-	public LazyIntArrayObjTags getTags$$PHOSPHORTAGGED() {
-		return new LazyIntArrayObjTags(tags);
-	}
-
-	@SuppressWarnings("unused")
-	public LazyIntArrayObjTags getTags$$PHOSPHORTAGGED(ControlTaintTagStack ctrl) {
-		return new LazyIntArrayObjTags(tags);
-	}
-
-	public SimpleHashSet<T> getDependencies() {
-		return dependencies;
-	}
-
-	@SuppressWarnings("unused")
-	public SimpleHashSet<T> getDependencies$$PHOSPHORTAGGED() {
-		return getDependencies();
 	}
 
 	public Taint(Taint<T> t1) {
@@ -184,9 +94,91 @@ public final class Taint<T> implements Serializable {
 		}
 	}
 
-	public Taint() {
-		if(TAINT_ARRAY_SIZE > 0)
-			tags = new int[TAINT_ARRAY_SIZE];
+	public static boolean isIgnoreTainting() {
+		return IGNORE_TAINTING;
+	}
+
+	public static final <T> Taint<T> copyTaint(Taint<T> in) {
+		return in;
+	}
+
+	public Taint<T> copy() {
+		return this;
+	}
+
+//	public Object clone()  {
+//		try {
+//			Object ret = super.clone();
+//			Taint r = (Taint) ret;
+//			r.dependencies = (LinkedList<Taint>) dependencies.clone();
+//			return ret;
+//		} catch (CloneNotSupportedException e) {
+//			e.printStackTrace();
+//
+//			return null;
+//		}
+//	}
+
+	@Override
+	public String toString() {
+		String depStr = " deps = [" + (dependencies != null ? dependencies.toString() : "") + "]";
+		return "Taint [lbl=" + lbl + " " + depStr + "]";
+	}
+
+	public void setBit(int tag) {
+		int bits = tag % 31;
+		int key = tag / 31;
+		tags[key] |= 1 << bits;
+	}
+
+	public boolean hasBitSet(int tag) {
+		int bits = tag % 31;
+		int key = tag / 31;
+		return (tags[key] & (1 << bits)) != 0;
+	}
+
+	public void setBits(int[] otherTags) {
+		for(int i = 0; i < otherTags.length; i++) {
+			tags[i] |= otherTags[i];
+		}
+	}
+
+	private boolean setBitsIfNeeded(int[] otherTags) {
+		boolean changed = false;
+		for (int i = 0; i < otherTags.length; i++) {
+			if ((tags[i] | otherTags[i]) != tags[i]) {
+				tags[i] |= otherTags[i];
+				changed = true;
+			}
+		}
+		return changed;
+	}
+
+	public T getLbl() {
+		return lbl;
+	}
+
+	public int[] getTags() {
+		return tags;
+	}
+
+	@SuppressWarnings("unused")
+	public LazyIntArrayObjTags getTags$$PHOSPHORTAGGED() {
+		return new LazyIntArrayObjTags(tags);
+	}
+
+	@SuppressWarnings("unused")
+	public LazyIntArrayObjTags getTags$$PHOSPHORTAGGED(ControlTaintTagStack ctrl) {
+		return new LazyIntArrayObjTags(tags);
+	}
+
+	public SimpleHashSet<T> getDependencies() {
+		return dependencies;
+	}
+
+	@SuppressWarnings("unused")
+	public SimpleHashSet<T> getDependencies$$PHOSPHORTAGGED() {
+		return getDependencies();
 	}
 
 	public boolean addDependency(Taint<T> d) {

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/Taint.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/Taint.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 
 public final class Taint<T> implements Serializable {
 
+	// TODO is this used somewhere?
 	private static boolean IGNORE_TAINTING;
 	private static int TAINT_ARRAY_SIZE = -1;
 
@@ -23,6 +24,10 @@ public final class Taint<T> implements Serializable {
 
 	public static Taint createTaint(int startingTag) {
 		return new Taint(startingTag);
+	}
+
+	public static <T> Taint createTaint$$PHOSPHORTAGGED(T lbl) {
+		return Taint.createTaint(lbl);
 	}
 
 	public static <T> Taint createTaint(T lbl) {
@@ -42,12 +47,12 @@ public final class Taint<T> implements Serializable {
 			tags = new int[TAINT_ARRAY_SIZE];
 		}
 		else {
-			tags = new int[0];
+			tags = null;
 		}
 
 		debug = false;
 		lbl = null;
-		dependencies = new SimpleHashSet<T>();
+		dependencies = null;
 	}
 
 	private Taint(int startingTag) {
@@ -56,7 +61,7 @@ public final class Taint<T> implements Serializable {
 
 		debug = false;
 		lbl = null;
-		dependencies = new SimpleHashSet<T>();
+		dependencies = null;
 	}
 
 	private Taint(T lbl) {
@@ -64,7 +69,7 @@ public final class Taint<T> implements Serializable {
 		dependencies = new SimpleHashSet<T>();
 
 		debug = false;
-		tags = new int[Math.max(TAINT_ARRAY_SIZE, 0)];
+		tags = null;
 	}
 
 	// TODO why would we create a taint from another taint?
@@ -241,6 +246,10 @@ public final class Taint<T> implements Serializable {
 			}
 		}
 		return changed;
+	}
+
+	public T getLbl$$PHOSPHORTAGGED() {
+		return this.getLbl();
 	}
 
 	public T getLbl() {

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/Taint.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/Taint.java
@@ -52,7 +52,7 @@ public final class Taint<T> implements Serializable {
 
 		debug = false;
 		lbl = null;
-		dependencies = null;
+		dependencies = new SimpleHashSet<T>();
 	}
 
 	private Taint(int startingTag) {

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/Taint.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/Taint.java
@@ -7,8 +7,19 @@ import edu.columbia.cs.psl.phosphor.struct.*;
 import java.io.Serializable;
 import java.util.Arrays;
 
-public class Taint<T> implements Serializable {
-	public static boolean IGNORE_TAINTING;
+public final class Taint<T> implements Serializable {
+
+	private static boolean IGNORE_TAINTING;
+	private static int TAINT_ARRAY_SIZE = -1;
+
+	private transient Object debug;
+	private T lbl;
+	private SimpleHashSet<T> dependencies;
+	private int[] tags;
+
+	public static boolean isIgnoreTainting() {
+		return IGNORE_TAINTING;
+	}
 
 	public static final <T> Taint<T> copyTaint(Taint<T> in) {
 		return in == null ? null : in.copy();
@@ -45,17 +56,10 @@ public class Taint<T> implements Serializable {
 		return "Taint [lbl=" + lbl + " " + depStr + "]";
 	}
 
-	public transient Object debug;
-	public T lbl;
-	public SimpleHashSet<T> dependencies;
-	public int[] tags;
-
 	public Taint(int startingTag) {
 		tags = new int[TAINT_ARRAY_SIZE];
 		setBit(startingTag);
 	}
-
-	public static int TAINT_ARRAY_SIZE = -1;
 
 	public void setBit(int tag) {
 		int bits = tag % 31;
@@ -91,7 +95,7 @@ public class Taint<T> implements Serializable {
 		dependencies = new SimpleHashSet<T>();
 	}
 
-	public T getLabel() {
+	public T getLbl() {
 		return lbl;
 	}
 

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/Taint.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/Taint.java
@@ -280,6 +280,10 @@ public final class Taint<T> implements Serializable {
 	}
 
 	public static <T> Taint<T> addDependency(Taint<T> oldTaint, Taint<T> d) {
+		if(oldTaint.contains(d)) {
+			return oldTaint;
+		}
+
 		Taint<T> newTaint = Taint.createTaint(oldTaint);
 		newTaint.addDependency(d);
 
@@ -366,7 +370,7 @@ public final class Taint<T> implements Serializable {
 	public static <T> void _combineTagsInPlace(Object obj, Taint<T> t1) {
 		Taint<T> t = (Taint<T>) TaintUtils.getTaintObj(obj);
 		if(t == null) {
-			MultiTainter.taintedObject(obj, new Taint(t1));
+			MultiTainter.taintedObject(obj, t1);
 		}
 		else {
 			t.addDependency(t1);
@@ -380,14 +384,14 @@ public final class Taint<T> implements Serializable {
 			return t1;
 		} else if(t1 == null || (t1.lbl == null && t1.hasNoDependencies())) {
 			return t2;
-//		} else if(t1.equals(t2) || IGNORE_TAINTING) {
-//			return t1;
-//		} else if(t1.contains(t2)) {
-//			return t1;
-//		} else if(t2.contains(t1)) {
-//			return t2;
+		} else if(t1.equals(t2) || IGNORE_TAINTING) {
+			return t1;
+		} else if(t1.contains(t2)) {
+			return t1;
+		} else if(t2.contains(t1)) {
+			return t2;
 		} else {
-			Taint<T> r = new Taint<T>(t1,t2);
+			Taint<T> r = Taint.createTaint(t1,t2);
 			if(Configuration.derivedTaintListener != null) {
 				Configuration.derivedTaintListener.doubleDepCreated(t1, t2, r);
 			}

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/TaintSourceWrapper.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/TaintSourceWrapper.java
@@ -39,7 +39,7 @@ public class TaintSourceWrapper<T extends AutoTaintLabel> {
 				if(array.taints[i] == null)
 					array.taints[i] = tag.copy();
 				else
-					array.taints[i].addDependency(tag);
+					array.taints[i] = Taint.addDependency(array.taints[i], tag);
 			}
 
 		}else if (inputArray instanceof Object[])
@@ -51,10 +51,12 @@ public class TaintSourceWrapper<T extends AutoTaintLabel> {
 				{
 
 					Taint existing = (Taint) ((TaintedWithObjTag) o).getPHOSPHOR_TAG();
-					if(existing != null)
-						existing.addDependency(tag);
-					else
-						((TaintedWithObjTag) o).setPHOSPHOR_TAG(tag.copy());
+          if (existing != null) {
+            existing = Taint.addDependency(existing, tag);
+            ((TaintedWithObjTag) o).setPHOSPHOR_TAG(existing);
+          } else {
+            ((TaintedWithObjTag) o).setPHOSPHOR_TAG(tag.copy());
+          }
 				}
 			}
 		}
@@ -64,7 +66,7 @@ public class TaintSourceWrapper<T extends AutoTaintLabel> {
 		StackTraceElement[] st = Thread.currentThread().getStackTrace();
 		StackTraceElement[] s = new StackTraceElement[st.length - 3];
 		System.arraycopy(st, 3, s, 0, s.length);
-		return new Taint<>(new AutoTaintLabel(source, s));
+		return Taint.createTaint(new AutoTaintLabel(source, s));
 	}
 
 	/* Called by sources for the arguments and return value. Adds a new taint tag to the specified object. */
@@ -95,7 +97,8 @@ public class TaintSourceWrapper<T extends AutoTaintLabel> {
 	public TaintedWithObjTag autoTaint(TaintedWithObjTag ret, String source, int argIdx, Taint<? extends AutoTaintLabel> tag) {
         Taint prevTag = (Taint)ret.getPHOSPHOR_TAG();
         if(prevTag != null) {
-            prevTag.addDependency(tag);
+            prevTag = Taint.addDependency(prevTag, tag);
+            ret.setPHOSPHOR_TAG(prevTag);
         } else {
             ret.setPHOSPHOR_TAG(tag);
         }
@@ -110,7 +113,7 @@ public class TaintSourceWrapper<T extends AutoTaintLabel> {
 				if(taintArray[i] == null)
 					taintArray[i] = tag.copy();
 				else
-					taintArray[i].addDependency(tag);
+					taintArray[i] = Taint.addDependency(taintArray[i], tag);
 			}
 		} else {
 			ret.setTaints(tag);
@@ -121,7 +124,7 @@ public class TaintSourceWrapper<T extends AutoTaintLabel> {
 	@SuppressWarnings("unchecked")
 	public TaintedPrimitiveWithObjTag autoTaint(TaintedPrimitiveWithObjTag ret, String source, int argIdx, Taint<? extends AutoTaintLabel> tag) {
 		if (ret.taint != null)
-			ret.taint.addDependency(tag);
+			ret.taint = Taint.addDependency(ret.taint, tag);
 		else
 			ret.taint = tag;
 		return ret;

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/ControlTaintTagStack.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/ControlTaintTagStack.java
@@ -147,9 +147,9 @@ public final class ControlTaintTagStack {
 				{
 					found = true;
 					if(taints.taint.getTags() != null)
-						i.entry.tag.setBits(taints.taint.getTags());
+						i.entry.tag = Taint.setBits(i.entry.tag, taints.taint.getTags());
 					else
-						i.entry.tag.addDependency(taints.taint);
+						i.entry.tag = Taint.addDependency(i.entry.tag, taints.taint);
 					break;
 				}
 				i = i.next;
@@ -215,12 +215,12 @@ public final class ControlTaintTagStack {
 		}
 		if (this.taint == null)
 		{
-			this.taint = new Taint(tag);
+			this.taint = Taint.createTaint(tag);
 		}
 		else {
 			Taint prevTaint = this.taint;
 			this.taint = prevTaint.copy();
-			this.taint.addDependency(tag);
+			this.taint = Taint.addDependency(this.taint, tag);
 
 		}
 		return prev;
@@ -235,12 +235,12 @@ public final class ControlTaintTagStack {
 		prevTaints.addFast(this.taint);
 		if (this.taint == null)
 		{
-			this.taint = new Taint(tag);
+			this.taint = Taint.createTaint(tag);
 		}
 		else {
 			Taint prevTaint = this.taint;
 			this.taint = prevTaint.copy();
-			this.taint.addDependency(tag);
+			this.taint = Taint.addDependency(this.taint, tag);
 
 		}
 		return ret;
@@ -312,13 +312,13 @@ public final class ControlTaintTagStack {
 		if(influenceExceptions == null || influenceExceptions.isEmpty())
 			return ret.copy();
 		if(ret == null)
-			ret = new Taint();
+			ret = Taint.createTaint();
 		else
 			ret = ret.copy();
 		LinkedList.Node<MaybeThrownException> n = influenceExceptions.getFirst();
 		while(n != null){
 			if(n.entry != null && n.entry.tag != null)
-				ret.addDependency(n.entry.tag);
+				ret = Taint.addDependency(ret, n.entry.tag);
 			n=n.next;
 		}
 		return ret;

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/ControlTaintTagStack.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/ControlTaintTagStack.java
@@ -303,7 +303,7 @@ public final class ControlTaintTagStack {
 
 	public Taint copyTagExceptions(){
 		if(
-				(taint == null || (taint.hasNoDependencies() && taint.getTags() == null))
+				(taint == null || (taint.hasNoDependencies() && taint.getLbl() == null))
 				&& (influenceExceptions == null || influenceExceptions.isEmpty())
 		){
 			return null;
@@ -324,7 +324,7 @@ public final class ControlTaintTagStack {
 		return ret;
 	}
 	public Taint getTag() {
-		if(taint == null || isDisabled || (taint.hasNoDependencies() && taint.getTags() == null))
+		if(taint == null || isDisabled || (taint.hasNoDependencies() && taint.getLbl() == null))
 			return null;
 		return taint;
 	}

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/ControlTaintTagStack.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/ControlTaintTagStack.java
@@ -12,7 +12,7 @@ public final class ControlTaintTagStack {
 
 	public LinkedList<MaybeThrownException> influenceExceptions;// = new LinkedList<>();
 	public final boolean isEmpty() {
-		return taint == null || this.isDisabled || (taint.lbl == null && taint.hasNoDependencies());
+		return taint == null || this.isDisabled || (taint.getLbl() == null && taint.hasNoDependencies());
 	}
 	public ControlTaintTagStack(int zz) {
 		this();
@@ -146,8 +146,8 @@ public final class ControlTaintTagStack {
 				if(i.entry != null && i.entry.clazz == t)
 				{
 					found = true;
-					if(taints.taint.tags != null)
-						i.entry.tag.setBits(taints.taint.tags);
+					if(taints.taint.getTags() != null)
+						i.entry.tag.setBits(taints.taint.getTags());
 					else
 						i.entry.tag.addDependency(taints.taint);
 					break;
@@ -303,7 +303,7 @@ public final class ControlTaintTagStack {
 
 	public Taint copyTagExceptions(){
 		if(
-				(taint == null || (taint.hasNoDependencies() && taint.lbl == null))
+				(taint == null || (taint.hasNoDependencies() && taint.getTags() == null))
 				&& (influenceExceptions == null || influenceExceptions.isEmpty())
 		){
 			return null;
@@ -324,7 +324,7 @@ public final class ControlTaintTagStack {
 		return ret;
 	}
 	public Taint getTag() {
-		if(taint == null || isDisabled || (taint.hasNoDependencies() && taint.lbl == null))
+		if(taint == null || isDisabled || (taint.hasNoDependencies() && taint.getTags() == null))
 			return null;
 		return taint;
 	}

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/ExceptionalTaintData.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/ExceptionalTaintData.java
@@ -11,13 +11,13 @@ public class ExceptionalTaintData {
 		prevTaints.addFast(this.taint);
 		if(this.taint == null)
 		{
-			this.taint = new Taint(tag);
+			this.taint = Taint.createTaint(tag);
 		}
 		else
 		{
 			if(!this.taint.contains(tag)) {
 				this.taint = this.taint.copy();
-				this.taint.addDependency(tag);
+				this.taint = Taint.addDependency(this.taint, tag);
 			}
 		}
 	}

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/LazyBooleanArrayObjTags.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/LazyBooleanArrayObjTags.java
@@ -45,7 +45,7 @@ public final class LazyBooleanArrayObjTags extends LazyArrayObjTags {
 		else if(tag == null)
 			set(l, idx, idxTag, ival);
 		else
-			set(l, idx, new Taint(tag, idxTag), ival);
+			set(l, idx, Taint.createTaint(tag, idxTag), ival);
 	}
 
 	public void set(boolean[] b, int idx, Taint tag, boolean val) {

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/LazyByteArrayObjTags.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/LazyByteArrayObjTags.java
@@ -46,7 +46,7 @@ public final class LazyByteArrayObjTags extends LazyArrayObjTags {
 		else if(tag == null)
 			set(l, idx, idxTag, ival);
 		else
-			set(l, idx, new Taint(tag, idxTag), ival);
+			set(l, idx, Taint.createTaint(tag, idxTag), ival);
 	}
 
 	public void set(byte[] b, int idx, Taint tag, byte val) {

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/LazyCharArrayObjTags.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/LazyCharArrayObjTags.java
@@ -49,7 +49,7 @@ public final class LazyCharArrayObjTags extends LazyArrayObjTags {
 		else if (tag == null)
 			set(l, idx, idxTag, ival);
 		else
-			set(l, idx, new Taint(tag, idxTag), ival);
+			set(l, idx, Taint.createTaint(tag, idxTag), ival);
 	}
 
 	public void set(char[] c, int idx, Taint tag, char val) {

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/LazyDoubleArrayObjTags.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/LazyDoubleArrayObjTags.java
@@ -56,7 +56,7 @@ public final class LazyDoubleArrayObjTags extends LazyArrayObjTags {
 		else if(tag == null)
 			set(l, idx, idxTag, ival);
 		else
-			set(l, idx, new Taint(tag, idxTag), ival);
+			set(l, idx, Taint.createTaint(tag, idxTag), ival);
 	}
 
 	public void set(double[] d, int idx, Taint tag, double newval) {

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/LazyFloatArrayObjTags.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/LazyFloatArrayObjTags.java
@@ -44,7 +44,7 @@ public final class LazyFloatArrayObjTags extends LazyArrayObjTags {
 		else if(tag == null)
 			set(l, idx, idxTag, ival);
 		else
-			set(l, idx, new Taint(tag, idxTag), ival);
+			set(l, idx, Taint.createTaint(tag, idxTag), ival);
 	}
 	
 	public void set(float[] f, int idx, Taint tag, float fval) {

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/LazyIntArrayObjTags.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/LazyIntArrayObjTags.java
@@ -56,7 +56,7 @@ public final class LazyIntArrayObjTags extends LazyArrayObjTags {
 		else if(tag == null)
 			set(l, idx, idxTag, ival);
 		else
-			set(l, idx, new Taint(tag, idxTag), ival);
+			set(l, idx, Taint.createTaint(tag, idxTag), ival);
 	}
 
 	public void set(int[] l, int idx, Taint tag, int ival) {

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/LazyLongArrayObjTags.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/LazyLongArrayObjTags.java
@@ -51,7 +51,7 @@ public final class LazyLongArrayObjTags extends LazyArrayObjTags {
 		else if(tag == null)
 			set(l, idx, idxTag, ival);
 		else
-			set(l, idx, new Taint(tag, idxTag), ival);
+			set(l, idx, Taint.createTaint(tag, idxTag), ival);
 	}
 	
 	public void set(long[] b, int idx, Taint tag, long lval) {

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/LazyShortArrayObjTags.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/LazyShortArrayObjTags.java
@@ -52,7 +52,7 @@ public final class LazyShortArrayObjTags extends LazyArrayObjTags {
 		else if(tag == null)
 			set(l, idx, idxTag, ival);
 		else
-			set(l, idx, new Taint(tag, idxTag), ival);
+			set(l, idx, Taint.createTaint(tag, idxTag), ival);
 	}
 
 	public void set(short[] g, int idx, Taint tag, short sval) {

--- a/Phosphor/test/edu/columbia/cs/psl/phosphor/ds/ControlTaintTagTest.java
+++ b/Phosphor/test/edu/columbia/cs/psl/phosphor/ds/ControlTaintTagTest.java
@@ -5,12 +5,12 @@ import org.junit.Test;
 public class ControlTaintTagTest {
 	@Test
 	public void testAddControlTag() throws Exception {
-//		Taint tag = new Taint("a");
-//		Taint tag3 = new Taint("a3");
+//		Taint tag = Taint.createTaint("a");
+//		Taint tag3 = Taint.createTaint("a3");
 //
-//		Taint tag2 = new Taint("a2");
+//		Taint tag2 = Taint.createTaint("a2");
 //		ControlTaintTagStack ctrl = new ControlTaintTagStack();
-//		Taint tag5 = new Taint(tag2);
+//		Taint tag5 = Taint.createTaint(tag2);
 //		tag = ctrl.push(tag);
 //		tag3 = ctrl.push(tag3);
 //		tag2 = ctrl.push(tag2);

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/ArrayLengthObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/ArrayLengthObjTagITCase.java
@@ -19,7 +19,7 @@ public class ArrayLengthObjTagITCase extends BasePhosphorTest {
 		int[] ar = new int[i];
 		Taint r = MultiTainter.getTaint(ar.length);
 		if (Configuration.ARRAY_LENGTH_TRACKING)
-			assertEquals(t.lbl, r.lbl);
+			assertEquals(t.getLbl(), r.getLbl());
 		else
 			assertNull(r);
 	}
@@ -31,7 +31,7 @@ public class ArrayLengthObjTagITCase extends BasePhosphorTest {
 		String[] ar = new String[i];
 		Taint r = MultiTainter.getTaint(ar.length);
 		if (Configuration.ARRAY_LENGTH_TRACKING)
-			assertEquals(t.lbl, r.lbl);
+			assertEquals(t.getLbl(), r.getLbl());
 		else
 			assertNull(r);
 	}
@@ -43,12 +43,12 @@ public class ArrayLengthObjTagITCase extends BasePhosphorTest {
 		int[][] ar = new int[i][i];
 		Taint r = MultiTainter.getTaint(ar.length);
 		if (Configuration.ARRAY_LENGTH_TRACKING)
-			assertEquals(t.lbl, r.lbl);
+			assertEquals(t.getLbl(), r.getLbl());
 		else
 			assertNull(r);
 		r = MultiTainter.getTaint(ar[0].length);
 		if (Configuration.ARRAY_LENGTH_TRACKING)
-			assertEquals(t.lbl, r.lbl);
+			assertEquals(t.getLbl(), r.getLbl());
 		else
 			assertNull(r);
 	}
@@ -60,12 +60,12 @@ public class ArrayLengthObjTagITCase extends BasePhosphorTest {
 		String[][] ar = new String[i][i];
 		Taint r = MultiTainter.getTaint(ar.length);
 		if (Configuration.ARRAY_LENGTH_TRACKING)
-			assertEquals(t.lbl, r.lbl);
+			assertEquals(t.getLbl(), r.getLbl());
 		else
 			assertNull(r);
 		r = MultiTainter.getTaint(ar[0].length);
 		if (Configuration.ARRAY_LENGTH_TRACKING)
-			assertEquals(t.lbl, r.lbl);
+			assertEquals(t.getLbl(), r.getLbl());
 		else
 			assertNull(r);
 	}
@@ -79,7 +79,7 @@ public class ArrayLengthObjTagITCase extends BasePhosphorTest {
 		int j = ar[i];
 		Taint r = MultiTainter.getTaint(ar[i]);
 		if (Configuration.ARRAY_LENGTH_TRACKING)
-			assertEquals(t.lbl, r.lbl);
+			assertEquals(t.getLbl(), r.getLbl());
 		else
 			assertNull(r);
 		String[] s = new String[10];
@@ -87,7 +87,7 @@ public class ArrayLengthObjTagITCase extends BasePhosphorTest {
 			s[j] = "b";
 		r = (Taint) MultiTainter.getTaint(s[i]);
 		if (Configuration.ARRAY_LENGTH_TRACKING)
-			assertEquals(t.lbl, r.lbl);
+			assertEquals(t.getLbl(), r.getLbl());
 		else
 			assertNull(r);
 	}
@@ -102,7 +102,7 @@ public class ArrayLengthObjTagITCase extends BasePhosphorTest {
 		Taint r = MultiTainter.getTaint(ar[5]);
 
 		if (Configuration.ARRAY_LENGTH_TRACKING)
-			assertEquals(t.lbl, r.lbl);
+			assertEquals(t.getLbl(), r.getLbl());
 		else
 			assertNull(r);
 
@@ -110,7 +110,7 @@ public class ArrayLengthObjTagITCase extends BasePhosphorTest {
 		s[i] = "bar";
 		r = (Taint) MultiTainter.getTaint(s[5]);
 		if (Configuration.ARRAY_LENGTH_TRACKING)
-			assertEquals(t.lbl, r.lbl);
+			assertEquals(t.getLbl(), r.getLbl());
 		else
 			assertNull(r);
 	}

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/AutoTaintObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/AutoTaintObjTagITCase.java
@@ -94,7 +94,7 @@ public class AutoTaintObjTagITCase extends BaseMultiTaintClass {
 	@Test
 	public void testTaintThroughAppliesToArgsAtEndOfMethod() throws Exception {
 		TaintThroughExample ex = new TaintThroughExample();
-		MultiTainter.taintedObject(ex,new Taint("Test"));
+		MultiTainter.taintedObject(ex,Taint.createTaint("Test"));
 
 		int[] ar = new int[10];
 
@@ -123,7 +123,7 @@ public class AutoTaintObjTagITCase extends BaseMultiTaintClass {
 	@Test
 	public void testPrimitiveTaintThrough() throws Exception {
 		TaintThroughExample taintedObj = new TaintThroughExample();
-		MultiTainter.taintedObject(taintedObj, new Taint("Test"));
+		MultiTainter.taintedObject(taintedObj, Taint.createTaint("Test"));
 		int ret = taintedObj.taintThroughInt();
 		assertNonNullTaint(ret);
 	}

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/AutoTaintObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/AutoTaintObjTagITCase.java
@@ -114,8 +114,8 @@ public class AutoTaintObjTagITCase extends BaseMultiTaintClass {
 		
 		assertNonNullTaint(s);
 		assertNonNullTaint(MultiTainter.getTaint(i));
-		assertTrue(MultiTainter.getTaint(i).lbl instanceof AutoTaintLabel);
-		assertTrue(MultiTainter.getTaint(ar[1]).lbl instanceof AutoTaintLabel);
+		assertTrue(MultiTainter.getTaint(i).getLbl() instanceof AutoTaintLabel);
+		assertTrue(MultiTainter.getTaint(ar[1]).getLbl() instanceof AutoTaintLabel);
 
 	}
 

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/BaseMultiTaintClass.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/BaseMultiTaintClass.java
@@ -17,7 +17,7 @@ public class BaseMultiTaintClass extends BasePhosphorTest{
 	{
 		if(taint != null)
 		{
-			if(taint.lbl == null && taint.hasNoDependencies())
+			if(taint.getLbl() == null && taint.hasNoDependencies())
 				return;
 			fail("Expected null taint. Got: " + taint);
 		}
@@ -29,7 +29,7 @@ public class BaseMultiTaintClass extends BasePhosphorTest{
 		{
 			return;
 		}
-		if(taint.lbl == null && taint.hasNoDependencies())
+		if(taint.getLbl() == null && taint.hasNoDependencies())
 			return;
 		fail("Expected null taint. Got: " + taint);
 	}
@@ -38,25 +38,25 @@ public class BaseMultiTaintClass extends BasePhosphorTest{
 	{
 		Taint t = (Taint) ((TaintedWithObjTag) obj).getPHOSPHOR_TAG();
 		assertNotNull(obj);
-		if(t == null || (t.lbl == null && t.hasNoDependencies()))
+		if(t == null || (t.getLbl() == null && t.hasNoDependencies()))
 			fail("Expected non-null taint - got: "  + t);
 	}
 
 	public static void assertNonNullTaint(Taint obj)
 	{
 		assertNotNull(obj);
-		if(obj.lbl == null && obj.hasNoDependencies())
+		if(obj.getLbl()== null && obj.hasNoDependencies())
 			fail("Expected non-null taint - got: "  + obj);
 	}
 	
 	public static void assertTaintHasLabel(Taint obj, Object lbl)
 	{
 		assertNotNull(obj);
-		if(obj.lbl == lbl)
+		if(obj.getLbl() == lbl)
 			return;
 		if(obj.hasNoDependencies())
 			fail("Expected taint contained "+ lbl+", has nothing");
-		for(Object o : obj.dependencies){
+		for(Object o : obj.getDependencies()){
 			if(o == lbl)
 				return;
 		}
@@ -65,12 +65,12 @@ public class BaseMultiTaintClass extends BasePhosphorTest{
 	public static void assertTaintHasOnlyLabel(Taint obj, Object lbl)
 	{
 		assertNotNull(obj);
-		if(obj.lbl == lbl)
+		if(obj.getLbl() == lbl)
 			return;
 		if(obj.hasNoDependencies())
 			fail("Expected taint contained "+ lbl+", has nothing");
 		boolean found = false;
-		for(Object o : obj.dependencies)
+		for(Object o : obj.getDependencies())
 		{
 			if(o == lbl)
 				found = true;
@@ -83,7 +83,7 @@ public class BaseMultiTaintClass extends BasePhosphorTest{
 	public static void assertTaintHasOnlyLabels(Taint obj, Object... lbl)
 	{
 		assertNotNull(obj);
-		if(obj.hasNoDependencies() && obj.lbl == null)
+		if(obj.hasNoDependencies() && obj.getLbl() == null)
 			fail("Expected taint contained "+ Arrays.toString(lbl)+", has nothing");
 		boolean l1 = false;
 		boolean l2 = false;
@@ -97,7 +97,7 @@ public class BaseMultiTaintClass extends BasePhosphorTest{
 			else
 				fail("Expected taint contained ONLY " + Arrays.toString(lbl) + ", found " + o);
 		}
-		expected.remove(obj.lbl);
+		expected.remove(obj.getLbl());
 		if(expected.isEmpty())
 			return;
 		fail("Expected taint contained "+ expected +", has " + obj);

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/DroidBenchImplicitITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/DroidBenchImplicitITCase.java
@@ -37,8 +37,8 @@ public class DroidBenchImplicitITCase extends BaseMultiTaintClass {
 	static int i = 0;
 
 	public static String taintedString(String string) {
-		Object r = new String(MultiTainter.taintedCharArray(string.toCharArray(), new Taint("Some stuff")));
-		((TaintedWithObjTag) r).setPHOSPHOR_TAG(new Taint("Some tainted data " + (++i)));
+		Object r = new String(MultiTainter.taintedCharArray(string.toCharArray(), Taint.createTaint("Some stuff")));
+		((TaintedWithObjTag) r).setPHOSPHOR_TAG(Taint.createTaint("Some tainted data " + (++i)));
 		return (String) r;
 	}
 
@@ -312,8 +312,8 @@ public class DroidBenchImplicitITCase extends BaseMultiTaintClass {
 		public void doTest() {
 			ArrayList arrayList = new ArrayList();
 			LinkedList linkedList = new LinkedList();
-			((TaintedWithObjTag) arrayList).setPHOSPHOR_TAG(new Taint("arraylist tag"));
-			((TaintedWithObjTag) linkedList).setPHOSPHOR_TAG(new Taint("linkedlist tag"));
+			((TaintedWithObjTag) arrayList).setPHOSPHOR_TAG(Taint.createTaint("arraylist tag"));
+			((TaintedWithObjTag) linkedList).setPHOSPHOR_TAG(Taint.createTaint("linkedlist tag"));
 
 			leakInformationBit(linkedList);
 			leakInformationBit(arrayList);

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/DroidBenchImplicitITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/DroidBenchImplicitITCase.java
@@ -31,7 +31,7 @@ public class DroidBenchImplicitITCase extends BaseMultiTaintClass {
 
 	public static int getTaint(String description) {
 		Taint taint = MultiTainter.getTaint(description.toCharArray()[0]);
-		return (taint == null || (taint.lbl == null && taint.hasNoDependencies())) ? 0 : 1;
+		return (taint == null || (taint.getLbl() == null && taint.hasNoDependencies())) ? 0 : 1;
 	}
 
 	static int i = 0;
@@ -294,7 +294,7 @@ public class DroidBenchImplicitITCase extends BaseMultiTaintClass {
 				ex.printStackTrace();
 			}
 			//should be a sink here
-			assertTrue(MultiTainter.getTaint(passwordCorrect) != null && (MultiTainter.getTaint(passwordCorrect).lbl != null || !MultiTainter.getTaint(passwordCorrect).hasNoDependencies()));
+			assertTrue(MultiTainter.getTaint(passwordCorrect) != null && (MultiTainter.getTaint(passwordCorrect).getLbl() != null || !MultiTainter.getTaint(passwordCorrect).hasNoDependencies()));
 //			assertTrue(false); //We have no concept of exceptional control flow tainting yet
 		}
 
@@ -324,11 +324,11 @@ public class DroidBenchImplicitITCase extends BaseMultiTaintClass {
 			if (list instanceof ArrayList) {
 				boolean labeledWithCurrentTag = false;
 				assertTrue(MultiTainter.getTaint(labeledWithCurrentTag) != null
-						&& (MultiTainter.getTaint(labeledWithCurrentTag).lbl != null || !MultiTainter.getTaint(labeledWithCurrentTag).hasNoDependencies()));
+						&& (MultiTainter.getTaint(labeledWithCurrentTag).getLbl() != null || !MultiTainter.getTaint(labeledWithCurrentTag).hasNoDependencies()));
 			} else if (list instanceof LinkedList) {
 				boolean labeledWithCurrentTag = false;
 				assertTrue(MultiTainter.getTaint(labeledWithCurrentTag) != null
-						&& (MultiTainter.getTaint(labeledWithCurrentTag).lbl != null || !MultiTainter.getTaint(labeledWithCurrentTag).hasNoDependencies()));
+						&& (MultiTainter.getTaint(labeledWithCurrentTag).getLbl() != null || !MultiTainter.getTaint(labeledWithCurrentTag).hasNoDependencies()));
 			}
 		}
 	}
@@ -481,7 +481,7 @@ public class DroidBenchImplicitITCase extends BaseMultiTaintClass {
 			passwordCorrect = true;
 		assertNullOrEmpty(MultiTainter.getControlFlow().getTag());
 		Taint taint = MultiTainter.getTaint(passwordCorrect);
-		assertTrue(MultiTainter.getTaint(passwordCorrect) != null && (MultiTainter.getTaint(passwordCorrect).lbl != null || !MultiTainter.getTaint(passwordCorrect).hasNoDependencies()));
+		assertTrue(MultiTainter.getTaint(passwordCorrect) != null && (MultiTainter.getTaint(passwordCorrect).getLbl() != null || !MultiTainter.getTaint(passwordCorrect).hasNoDependencies()));
 	}
 
 	public void testImplicitFlow2p2() {
@@ -491,7 +491,7 @@ public class DroidBenchImplicitITCase extends BaseMultiTaintClass {
 		if (userInputPassword.equals("superSecure"))
 			passwordCorrect = true;
 		Taint taint = MultiTainter.getTaint(passwordCorrect);
-		assertTrue(MultiTainter.getTaint(passwordCorrect) != null && (MultiTainter.getTaint(passwordCorrect).lbl != null || !MultiTainter.getTaint(passwordCorrect).hasNoDependencies()));
+		assertTrue(MultiTainter.getTaint(passwordCorrect) != null && (MultiTainter.getTaint(passwordCorrect).getLbl() != null || !MultiTainter.getTaint(passwordCorrect).hasNoDependencies()));
 	}
 
 	@Test

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/DroidBenchObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/DroidBenchObjTagITCase.java
@@ -48,7 +48,7 @@ public class DroidBenchObjTagITCase extends BasePhosphorTest {
 
 	public static String taintedString(String string) {
 		Object r = new String(string.toCharArray());
-		((TaintedWithObjTag) r).setPHOSPHOR_TAG(new Taint("Some tainted data " + (++i)));
+		((TaintedWithObjTag) r).setPHOSPHOR_TAG(Taint.createTaint("Some tainted data " + (++i)));
 		return (String) r;
 	}
 
@@ -304,8 +304,8 @@ public class DroidBenchObjTagITCase extends BasePhosphorTest {
 		public void doTest() {
 			ArrayList arrayList = new ArrayList();
 			LinkedList linkedList = new LinkedList();
-			((TaintedWithObjTag) arrayList).setPHOSPHOR_TAG(new Taint("arraylist tag"));
-			((TaintedWithObjTag) linkedList).setPHOSPHOR_TAG(new Taint("arraylist tag"));
+			((TaintedWithObjTag) arrayList).setPHOSPHOR_TAG(Taint.createTaint("arraylist tag"));
+			((TaintedWithObjTag) linkedList).setPHOSPHOR_TAG(Taint.createTaint("arraylist tag"));
 
 			leakInformationBit(linkedList);
 			leakInformationBit(arrayList);

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/DroidBenchObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/DroidBenchObjTagITCase.java
@@ -35,13 +35,13 @@ public class DroidBenchObjTagITCase extends BasePhosphorTest {
 		{
 			return;
 		}
-		if(taint.lbl == null && taint.hasNoDependencies())
+		if(taint.getLbl() == null && taint.hasNoDependencies())
 			return;
 		fail("Expected null taint. Got: " + taint);
 	}
 	public static int getTaint(String description) {
 		Taint taint = MultiTainter.getTaint(description.toCharArray()[0]);
-		return (taint == null || (taint.lbl == null && taint.hasNoDependencies())) ? 0 : 1;
+		return (taint == null || (taint.getLbl() == null && taint.hasNoDependencies())) ? 0 : 1;
 	}
 
 	static int i = 0;
@@ -281,7 +281,7 @@ public class DroidBenchObjTagITCase extends BasePhosphorTest {
 			String username = taintedString("hanns");
 			try {
 				boolean passwordCorrect = lookup(username, password);
-				assertTrue(MultiTainter.getTaint(passwordCorrect) != null && (MultiTainter.getTaint(passwordCorrect).lbl != null || !MultiTainter.getTaint(passwordCorrect).hasNoDependencies()));
+				assertTrue(MultiTainter.getTaint(passwordCorrect) != null && (MultiTainter.getTaint(passwordCorrect).getLbl() != null || !MultiTainter.getTaint(passwordCorrect).hasNoDependencies()));
 			} catch (Exception ex) {
 				//should be a sink here
 				ex.printStackTrace();
@@ -316,11 +316,11 @@ public class DroidBenchObjTagITCase extends BasePhosphorTest {
 			if (list instanceof ArrayList) {
 				boolean labeledWithCurrentTag = false;
 				assertTrue(MultiTainter.getTaint(labeledWithCurrentTag) != null
-						&& (MultiTainter.getTaint(labeledWithCurrentTag).lbl != null || !MultiTainter.getTaint(labeledWithCurrentTag).hasNoDependencies()));
+						&& (MultiTainter.getTaint(labeledWithCurrentTag).getLbl() != null || !MultiTainter.getTaint(labeledWithCurrentTag).hasNoDependencies()));
 			} else if (list instanceof LinkedList) {
 				boolean labeledWithCurrentTag = false;
 				assertTrue(MultiTainter.getTaint(labeledWithCurrentTag) != null
-						&& (MultiTainter.getTaint(labeledWithCurrentTag).lbl != null || !MultiTainter.getTaint(labeledWithCurrentTag).hasNoDependencies()));
+						&& (MultiTainter.getTaint(labeledWithCurrentTag).getLbl() != null || !MultiTainter.getTaint(labeledWithCurrentTag).hasNoDependencies()));
 			}
 		}
 	}
@@ -413,7 +413,7 @@ public class DroidBenchObjTagITCase extends BasePhosphorTest {
 		if (userInputPassword.equals("superSecure"))
 			passwordCorrect = true;
 		Taint taint = MultiTainter.getTaint(passwordCorrect);
-		assertTrue(MultiTainter.getTaint(passwordCorrect) != null && (MultiTainter.getTaint(passwordCorrect).lbl != null || !MultiTainter.getTaint(passwordCorrect).hasNoDependencies()));
+		assertTrue(MultiTainter.getTaint(passwordCorrect) != null && (MultiTainter.getTaint(passwordCorrect).getLbl() != null || !MultiTainter.getTaint(passwordCorrect).hasNoDependencies()));
 	}
 
 	@Test(expected=java.lang.AssertionError.class)

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/EnumObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/EnumObjTagITCase.java
@@ -13,10 +13,10 @@ public class EnumObjTagITCase extends BasePhosphorTest {
 	public void testEnumFlow() throws Exception {
 		String s = "abcd";
 		MultiTainter.taintedObject(s, new Taint("foo"));
-		assertEquals("foo", MultiTainter.getTaint(s).lbl);
+		assertEquals("foo", MultiTainter.getTaint(s).getLbl());
 		Dummy x = Dummy.a;
 		Dummy y = Dummy.valueOf(s);
-		assertEquals("foo", MultiTainter.getTaint(y).lbl);
+		assertEquals("foo", MultiTainter.getTaint(y).getLbl());
 		assertSame(y, Dummy.abcd);
 	}
 	@Test

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/EnumObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/EnumObjTagITCase.java
@@ -12,7 +12,7 @@ public class EnumObjTagITCase extends BasePhosphorTest {
 	@Test
 	public void testEnumFlow() throws Exception {
 		String s = "abcd";
-		MultiTainter.taintedObject(s, new Taint("foo"));
+		MultiTainter.taintedObject(s, Taint.createTaint("foo"));
 		assertEquals("foo", MultiTainter.getTaint(s).getLbl());
 		Dummy x = Dummy.a;
 		Dummy y = Dummy.valueOf(s);

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/FakeEnumTest.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/FakeEnumTest.java
@@ -8,7 +8,7 @@ public class FakeEnumTest extends BasePhosphorTest{
 public static void main(String[] args) {
 	System.out.println(Foo.A);
 	String a = "A";
-	MultiTainter.taintedObject(a, new Taint("Z"));;
+	MultiTainter.taintedObject(a, Taint.createTaint("Z"));
 	System.out.println(Foo.valueOf(a));
 	System.out.println(MultiTainter.getTaint(Foo.valueOf(a)));
 	System.out.println(MultiTainter.getTaint(a));

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/GeneralImplicitITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/GeneralImplicitITCase.java
@@ -206,12 +206,12 @@ public class GeneralImplicitITCase extends BaseMultiTaintClass {
 		resetState();
 		String x = "afoo";
 		String lbl = "taintedStr";
-		MultiTainter.taintedObject(x, new Taint(lbl));
+		MultiTainter.taintedObject(x, Taint.createTaint(lbl));
 		boolean a = x.contains("a");
 		assertTaintHasLabel(MultiTainter.getTaint(a), lbl);
 
 		String x2 = "foo";
-		MultiTainter.taintedObject(x, new Taint(lbl));
+		MultiTainter.taintedObject(x, Taint.createTaint(lbl));
 		boolean b = x.contains("a");
 		assertTaintHasLabel(MultiTainter.getTaint(b), lbl);
 	}

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/GeneralImplicitITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/GeneralImplicitITCase.java
@@ -62,7 +62,7 @@ public class GeneralImplicitITCase extends BaseMultiTaintClass {
         ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
         ObjectInputStream si = new ObjectInputStream(bis);
         b = (BigInteger) si.readObject();
-        System.out.println(b.toByteArray());
+//        System.out.println(b.toByteArray());
 	}
 
 	@Test

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/GetSetTaintObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/GetSetTaintObjTagITCase.java
@@ -16,13 +16,13 @@ public class GetSetTaintObjTagITCase extends BaseMultiTaintClass{
 	public void testReferenceType() throws Exception {
 		String s = "def";
 		HashMap<Object, Object> m =  new HashMap<Object, Object>();
-		MultiTainter.taintedObject(s, new Taint("a"));;
-		MultiTainter.taintedObject(m, new Taint("a"));
+		MultiTainter.taintedObject(s, Taint.createTaint("a"));;
+		MultiTainter.taintedObject(m, Taint.createTaint("a"));
 		
 		int[] x = new int[10];
 		//In its default mode, Phosphor tracks ONLY for the array ELEMENTS - not for the reference
 		//can do -withArrayLengthTags to track a tag for the length of the array
-		x = MultiTainter.taintedIntArray(x, new Taint("b"));
+		x = MultiTainter.taintedIntArray(x, Taint.createTaint("b"));
 		
 		assertTrue(((TaintedWithObjTag)m).getPHOSPHOR_TAG() != null);
 		assertTrue(MultiTainter.getTaint(m) != null);
@@ -32,14 +32,14 @@ public class GetSetTaintObjTagITCase extends BaseMultiTaintClass{
 	@Test
 	public void testBoxing()
 	{
-		Boolean z = MultiTainter.taintedBoolean(false, new Taint("a"));
-		Byte b = MultiTainter.taintedByte((byte) 4, new Taint("a"));
-		Character c = MultiTainter.taintedChar('a', new Taint("a"));
-		Integer i = MultiTainter.taintedInt(4, new Taint("a"));
-		Short s = MultiTainter.taintedShort((short)5, new Taint("a"));
-		Long l = MultiTainter.taintedLong((long) 5, new Taint("a"));
-		Float f = MultiTainter.taintedFloat(4f, new Taint("a"));
-		Double d = MultiTainter.taintedDouble(4d, new Taint("a"));
+		Boolean z = MultiTainter.taintedBoolean(false, Taint.createTaint("a"));
+		Byte b = MultiTainter.taintedByte((byte) 4, Taint.createTaint("a"));
+		Character c = MultiTainter.taintedChar('a', Taint.createTaint("a"));
+		Integer i = MultiTainter.taintedInt(4, Taint.createTaint("a"));
+		Short s = MultiTainter.taintedShort((short)5, Taint.createTaint("a"));
+		Long l = MultiTainter.taintedLong((long) 5, Taint.createTaint("a"));
+		Float f = MultiTainter.taintedFloat(4f, Taint.createTaint("a"));
+		Double d = MultiTainter.taintedDouble(4d, Taint.createTaint("a"));
 		
 
 		assertTrue(MultiTainter.getTaint(z.booleanValue()) != null);
@@ -55,21 +55,21 @@ public class GetSetTaintObjTagITCase extends BaseMultiTaintClass{
 	@Test
 	public void testIntConstructorTaintsIntObject()
 	{
-		Integer i = new Integer(MultiTainter.taintedInt(5, new Taint("a")));
+		Integer i = new Integer(MultiTainter.taintedInt(5, Taint.createTaint("a")));
 		assertTrue(MultiTainter.getTaint(i)!=null);
 
 	}
 	@Test
 	public void testNotBoxing()
 	{
-		boolean z = MultiTainter.taintedBoolean(false, new Taint("a"));
-		byte b = MultiTainter.taintedByte((byte) 4, new Taint("a"));
-		char c = MultiTainter.taintedChar('a', new Taint("a"));
-		int i = MultiTainter.taintedInt(4, new Taint("a"));
-		short s = MultiTainter.taintedShort((short)5, new Taint("a"));
-		long l = MultiTainter.taintedLong((long) 5, new Taint("a"));
-		float f = MultiTainter.taintedFloat(4f, new Taint("a"));
-		double d = MultiTainter.taintedDouble(4d, new Taint("a"));
+		boolean z = MultiTainter.taintedBoolean(false, Taint.createTaint("a"));
+		byte b = MultiTainter.taintedByte((byte) 4, Taint.createTaint("a"));
+		char c = MultiTainter.taintedChar('a', Taint.createTaint("a"));
+		int i = MultiTainter.taintedInt(4, Taint.createTaint("a"));
+		short s = MultiTainter.taintedShort((short)5, Taint.createTaint("a"));
+		long l = MultiTainter.taintedLong((long) 5, Taint.createTaint("a"));
+		float f = MultiTainter.taintedFloat(4f, Taint.createTaint("a"));
+		double d = MultiTainter.taintedDouble(4d, Taint.createTaint("a"));
 		
 
 		assertTrue(MultiTainter.getTaint(z) != null);
@@ -85,14 +85,14 @@ public class GetSetTaintObjTagITCase extends BaseMultiTaintClass{
 	@Test
 	public void testToString()
 	{
-		boolean z = MultiTainter.taintedBoolean(false, new Taint("a"));
-		byte b = MultiTainter.taintedByte((byte) 4, new Taint("a"));
-		char c = MultiTainter.taintedChar('a', new Taint("a"));
-		int i = MultiTainter.taintedInt(4, new Taint("a"));
-		short s = MultiTainter.taintedShort((short)5, new Taint("a"));
-		long l = MultiTainter.taintedLong((long) 5, new Taint("a"));
-		float f = MultiTainter.taintedFloat(4f, new Taint("a"));
-		double d = MultiTainter.taintedDouble(4d, new Taint("a"));
+		boolean z = MultiTainter.taintedBoolean(false, Taint.createTaint("a"));
+		byte b = MultiTainter.taintedByte((byte) 4, Taint.createTaint("a"));
+		char c = MultiTainter.taintedChar('a', Taint.createTaint("a"));
+		int i = MultiTainter.taintedInt(4, Taint.createTaint("a"));
+		short s = MultiTainter.taintedShort((short)5, Taint.createTaint("a"));
+		long l = MultiTainter.taintedLong((long) 5, Taint.createTaint("a"));
+		float f = MultiTainter.taintedFloat(4f, Taint.createTaint("a"));
+		double d = MultiTainter.taintedDouble(4d, Taint.createTaint("a"));
 		assertNonNullTaint(Boolean.toString(z));
 		assertNonNullTaint(Byte.toString(b));
 		assertNonNullTaint(Character.toString(c));
@@ -109,8 +109,8 @@ public class GetSetTaintObjTagITCase extends BaseMultiTaintClass{
 		String hundred = new String(new char[]{'1','0','0'});
 		Object lbl = 5;
 		String TRUE = new String(new char[]{'t','r','u','e'});
-		((TaintedWithObjTag) ((Object) hundred)).setPHOSPHOR_TAG(new Taint(lbl));
-		((TaintedWithObjTag) ((Object) TRUE)).setPHOSPHOR_TAG(new Taint(lbl));
+		((TaintedWithObjTag) ((Object) hundred)).setPHOSPHOR_TAG(Taint.createTaint(lbl));
+		((TaintedWithObjTag) ((Object) TRUE)).setPHOSPHOR_TAG(Taint.createTaint(lbl));
 		boolean z = Boolean.parseBoolean(TRUE);
 		byte b = Byte.valueOf(hundred);
 		byte b2 = Byte.parseByte(hundred);

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/ReflectionImplicitITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/ReflectionImplicitITCase.java
@@ -193,7 +193,7 @@ public class ReflectionImplicitITCase extends BasePhosphorTest {
 	public void testInvokeMethodTaintedPrimitiveArg() throws Exception {
 		ReflectionObjTagITCase.MethodHolder holder = new MethodHolder(true);
 		Method method = ReflectionObjTagITCase.MethodHolder.class.getMethod("primitiveParamMethod", Boolean.TYPE);
-		boolean z = MultiTainter.taintedBoolean(true, new Taint<>("PrimArgLabel"));
+		boolean z = MultiTainter.taintedBoolean(true, Taint.createTaint("PrimArgLabel"));
 		Object result = method.invoke(holder, z);
 		assertTrue("Expected integer return from reflected method.", result instanceof Integer);
 		int i = (Integer)result;
@@ -215,7 +215,7 @@ public class ReflectionImplicitITCase extends BasePhosphorTest {
 	public void testInvokeMethodTaintedPrimitiveArrArg() throws Exception {
 		ReflectionObjTagITCase.MethodHolder holder = new MethodHolder(true);
 		Method method = ReflectionObjTagITCase.MethodHolder.class.getMethod("primitiveArrParamMethod", Class.forName("[Z"));
-		boolean z = MultiTainter.taintedBoolean(true, new Taint<>("PrimArgLabel"));
+		boolean z = MultiTainter.taintedBoolean(true, Taint.createTaint("PrimArgLabel"));
 		boolean[] arr = new boolean[] {z, z};
 		Object result = method.invoke(holder, arr);
 		assertTrue("Expected integer return from reflected method.", result instanceof Integer);

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/ReflectionImplicitITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/ReflectionImplicitITCase.java
@@ -150,7 +150,7 @@ public class ReflectionImplicitITCase extends BasePhosphorTest {
 		// edu.columbia.cs.psl.phosphor.runtime.LazyArrayObjTags cannot be cast
 		// to edu.columbia.cs.psl.phosphor.runtime.Taint
 
-		assertEquals(MultiTainter.getTaint(arr[0]).lbl, MultiTainter.getTaint(ret).lbl);
+		assertEquals(MultiTainter.getTaint(arr[0]).getLbl(), MultiTainter.getTaint(ret).getLbl());
 	}
 
 	@Test

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/ReflectionObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/ReflectionObjTagITCase.java
@@ -118,7 +118,7 @@ public class ReflectionObjTagITCase extends BasePhosphorTest {
 		// edu.columbia.cs.psl.phosphor.runtime.LazyArrayObjTags cannot be cast
 		// to edu.columbia.cs.psl.phosphor.runtime.Taint
 
-		assertEquals(MultiTainter.getTaint(arr[0]).lbl, MultiTainter.getTaint(ret).lbl);
+		assertEquals(MultiTainter.getTaint(arr[0]).getLbl(), MultiTainter.getTaint(ret).getLbl());
 	}
 
 	@Test

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/ReflectionObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/ReflectionObjTagITCase.java
@@ -161,7 +161,7 @@ public class ReflectionObjTagITCase extends BasePhosphorTest {
 	public void testInvokeMethodTaintedPrimitiveArg() throws Exception {
 		MethodHolder holder = new MethodHolder(true);
 		Method method = MethodHolder.class.getMethod("primitiveParamMethod", Boolean.TYPE);
-		boolean z = MultiTainter.taintedBoolean(true, new Taint<>("PrimArgLabel"));
+		boolean z = MultiTainter.taintedBoolean(true, Taint.createTaint("PrimArgLabel"));
 		Object result = method.invoke(holder, z);
 		assertTrue("Expected integer return from reflected method.", result instanceof Integer);
 		int i = (Integer)result;
@@ -183,7 +183,7 @@ public class ReflectionObjTagITCase extends BasePhosphorTest {
 	public void testInvokeMethodTaintedPrimitiveArrArg() throws Exception {
 		MethodHolder holder = new MethodHolder(true);
 		Method method = MethodHolder.class.getMethod("primitiveArrParamMethod", Class.forName("[Z"));
-		boolean z = MultiTainter.taintedBoolean(true, new Taint<>("PrimArgLabel"));
+		boolean z = MultiTainter.taintedBoolean(true, Taint.createTaint("PrimArgLabel"));
 		boolean[] arr = new boolean[] {z, z};
 		Object result = method.invoke(holder, arr);
 		assertTrue("Expected integer return from reflected method.", result instanceof Integer);

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/StringConcatObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/StringConcatObjTagITCase.java
@@ -51,9 +51,9 @@ public class StringConcatObjTagITCase extends BasePhosphorTest {
 			char c = concate.charAt(i);
 			Taint ct = MultiTainter.getTaint(c);
 			if (i < 3) {
-				assertEquals(ct.lbl, "string");
+				assertEquals(ct.getLbl(), "string");
 			} else {
-				assertEquals(ct.lbl, "int");
+				assertEquals(ct.getLbl(), "int");
 			}
 		}
 	}

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/StringConcatObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/StringConcatObjTagITCase.java
@@ -13,7 +13,7 @@ public class StringConcatObjTagITCase extends BasePhosphorTest {
 	@Test
 	public void testLDCStringConcat() throws Exception {
 		String str1 = "abcdefg";
-		((TaintedWithObjTag)((Object)str1)).setPHOSPHOR_TAG(new Taint("sensitive"));
+		((TaintedWithObjTag)((Object)str1)).setPHOSPHOR_TAG(Taint.createTaint("sensitive"));
 		String str2 = "a"+str1;
 		assertTrue(MultiTainter.getTaint(str2.charAt(0)) == null);
 		assertTrue(MultiTainter.getTaint(str2.charAt(1)) != null);
@@ -22,7 +22,7 @@ public class StringConcatObjTagITCase extends BasePhosphorTest {
 	@Test
 	public void testNewStringConcat() throws Exception {
 		String str1 = new String("abcdefg");
-		((TaintedWithObjTag)((Object)str1)).setPHOSPHOR_TAG(new Taint("sensitive"));
+		((TaintedWithObjTag)((Object)str1)).setPHOSPHOR_TAG(Taint.createTaint("sensitive"));
 		String str2 = "a"+str1;
 		assertTrue(MultiTainter.getTaint(str2.charAt(0)) == null);
 		assertTrue(MultiTainter.getTaint(str2.charAt(1)) != null);
@@ -31,7 +31,7 @@ public class StringConcatObjTagITCase extends BasePhosphorTest {
 	@Test
 	public void testConcatAndMultiTainter() throws Exception {
 		String str1 = new String("abcdefg");
-		MultiTainter.taintedObject(str1, new Taint("Sensitive"));
+		MultiTainter.taintedObject(str1, Taint.createTaint("Sensitive"));
 		String str2 = str1 + "a";
 		assertTrue(MultiTainter.getTaint(str2.charAt(0)) != null);
 		assertTrue(MultiTainter.getTaint(str2.charAt(7)) == null);
@@ -42,7 +42,7 @@ public class StringConcatObjTagITCase extends BasePhosphorTest {
 		String s = "abc";
 		int val = 98;
 		
-		MultiTainter.taintedObject(s, new Taint("string"));
+		MultiTainter.taintedObject(s, Taint.createTaint("string"));
 		val = MultiTainter.taintedInt(val, "int");
 		
 		String concate = s + val;


### PR DESCRIPTION
In large systems, Phosphor is creating a lot of Taints that are equal, which creates a lot of memory overhead. The goal of these changes is to make the creating and reusing of Taints smarter to reduce the overhead.