### PR TITLE
Replace auto taint methods

### DIFF
--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/PreMain.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/PreMain.java
@@ -15,22 +15,17 @@ import java.security.MessageDigest;
 import java.security.ProtectionDomain;
 import java.util.List;
 
-import edu.columbia.cs.psl.phosphor.instrumenter.ClinitRetransformClassVisitor;
-import edu.columbia.cs.psl.phosphor.instrumenter.EclipseCompilerCV;
-import edu.columbia.cs.psl.phosphor.instrumenter.HidePhosphorFromASMCV;
+import edu.columbia.cs.psl.phosphor.instrumenter.*;
 import edu.columbia.cs.psl.phosphor.org.objectweb.asm.commons.OurJSRInlinerAdapter;
 import edu.columbia.cs.psl.phosphor.org.objectweb.asm.commons.OurSerialVersionUIDAdder;
 import org.objectweb.asm.*;
 import org.objectweb.asm.commons.SerialVersionUIDAdder;
 import org.objectweb.asm.tree.*;
 
-import edu.columbia.cs.psl.phosphor.instrumenter.TaintTrackingClassVisitor;
 import edu.columbia.cs.psl.phosphor.instrumenter.asm.OffsetPreservingClassReader;
 import edu.columbia.cs.psl.phosphor.runtime.TaintInstrumented;
 import edu.columbia.cs.psl.phosphor.runtime.TaintSourceWrapper;
 import edu.columbia.cs.psl.phosphor.struct.ControlTaintTagStack;
-import edu.columbia.cs.psl.phosphor.struct.LazyByteArrayIntTags;
-import edu.columbia.cs.psl.phosphor.struct.LazyByteArrayObjTags;
 import edu.columbia.cs.psl.phosphor.struct.TaintedWithIntTag;
 import edu.columbia.cs.psl.phosphor.struct.TaintedWithObjTag;
 import org.objectweb.asm.util.CheckClassAdapter;
@@ -289,6 +284,9 @@ public class PreMain {
 						_cv = new OurSerialVersionUIDAdder(new TaintTrackingClassVisitor(_cv, skipFrames, fields));
 					if(EclipseCompilerCV.isEclipseCompilerClass(className)) {
 						_cv = new EclipseCompilerCV(_cv);
+					}
+					if(OgnlUtilCV.isOgnlUtilClass(className)) {
+						_cv = new OgnlUtilCV(_cv);
 					}
 					_cv = new HidePhosphorFromASMCV(_cv, upgradeVersion);
 					if (Configuration.WITH_SELECTIVE_INST)

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/SourceSinkTransformer.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/SourceSinkTransformer.java
@@ -70,6 +70,7 @@ public class SourceSinkTransformer extends PhosphorBaseTransformer {
                 // Retransform clazz and any classes that were initialized before retransformation could occur.
                 while(!retransformQueue.isEmpty()) {
                     Class<?> poppedClazz = retransformQueue.pop();
+                    BasicSourceSinkManager.recordClass(poppedClazz);
                     if(poppedClazz.getName() != null && BasicSourceSinkManager.getInstance().isSourceOrSinkOrTaintThrough(poppedClazz)) {
                         // poppedClazz represents a class or interface that is or is a subtype of a class or interface with
                         // at least one method labeled as being a sink or source or taintThrough method

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/OgnlUtilCV.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/OgnlUtilCV.java
@@ -1,0 +1,49 @@
+package edu.columbia.cs.psl.phosphor.instrumenter;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+/* Disables Ognl expression caching by changing reads of the enableExpressionCache field to return false. */
+public class OgnlUtilCV extends ClassVisitor {
+
+    // The name of field whose reads are being changed
+    private static final String targetFieldName = "enableExpressionCache";
+
+    public OgnlUtilCV(ClassVisitor cv) {
+        super(Opcodes.ASM5, cv);
+    }
+
+    @Override
+    public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+        MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
+        return new OgnlUtilMV(mv);
+    }
+
+    private static class OgnlUtilMV extends MethodVisitor {
+
+        OgnlUtilMV(MethodVisitor mv) {
+            super(Opcodes.ASM5, mv);
+        }
+
+        @Override
+        public void visitFieldInsn(int opcode, String owner, String name, String desc) {
+            if(isOgnlUtilClass(owner) && name.equals(targetFieldName)) {
+                if(opcode == Opcodes.GETFIELD) {
+                    super.visitInsn(Opcodes.POP);
+                    super.visitInsn(Opcodes.ICONST_0);
+                } else if(opcode == Opcodes.GETSTATIC) {
+                    super.visitInsn(Opcodes.ICONST_0);
+                }
+            } else {
+                super.visitFieldInsn(opcode, owner, name, desc);
+            }
+        }
+
+    }
+
+    /* Returns whether the class with the specified name is OgnlUtil. */
+    public static boolean isOgnlUtilClass(String className) {
+        return className != null && className.equals("com/opensymphony/xwork2/ognl/OgnlUtil");
+    }
+}


### PR DESCRIPTION
Made it possible to replace the base set of sources, sinks, and taintThrough methods used in auto-tainting at runtime. Refactored BasicSourceSinkManager.