### PR TITLE
* Added standard prefix for "extra" fields added to class by phosphor…

### DIFF
--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/Configuration.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/Configuration.java
@@ -57,6 +57,8 @@ public class Configuration {
 	public static String STRING_SET_TAG_TAINT_CLASS = "edu/columbia/cs/psl/phosphor/runtime/TaintChecker";
 	public static boolean ALWAYS_CHECK_FOR_FRAMES = false;
 
+	public static Class<? extends ClassVisitor> PRIOR_CLASS_VISITOR = null;
+
 	public static class Method {
 		final String name;
 		final String owner;
@@ -121,7 +123,7 @@ public class Configuration {
 	public static Class TAINT_TAG_OBJ_CLASS = (Taint.class);
 	public static Class TAINT_TAG_OBJ_ARRAY_CLASS = (LazyArrayObjTags.class);
 	public static String TAINT_INTERFACE_INTERNALNAME = !MULTI_TAINTING ? "edu/columbia/cs/psl/phosphor/struct/TaintedWithIntTag" : "edu/columbia/cs/psl/phosphor/struct/TaintedWithObjTag";
-	
+
 	public static Class<? extends TaintAdapter> extensionMethodVisitor;
 	public static Class extensionClassVisitor;
 

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/Instrumenter.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/Instrumenter.java
@@ -244,7 +244,12 @@ public class Instrumenter {
 			.desc("Do not output local variable debug tables for generated local variables (useful for avoiding warnings from D8)")
 			.build();
 	static Option opt_alwaysCheckForFrames = Option.builder("alwaysCheckForFrames")
-			.desc("Always check to ensure that class files with version > Java 8 ACTUALLY have frames - useful for instrumenting android-targeting code that is compiled with Java 8 but without frames").build();
+			.desc("Always check to ensure that class files with version > Java 8 ACTUALLY have frames - useful for instrumenting android-targeting code that is compiled with Java 8 but without frames")
+			.build();
+	static Option opt_priorClassVisitor = Option.builder("priorClassVisitor")
+			.hasArg()
+			.desc("Specify the class name for a ClassVisitor class to be added to Phosphor's visitor chain before taint tracking is added to the class.")
+			.build();
 	static Option help = Option.builder("help")
 		.desc("print this message")
 		.build();
@@ -280,6 +285,7 @@ public class Instrumenter {
 		options.addOption(opt_withoutBranchNotTaken);
 		options.addOption(opt_disableLocalsInfo);
 		options.addOption(opt_alwaysCheckForFrames);
+		options.addOption(opt_priorClassVisitor);
 
 		CommandLineParser parser = new BasicParser();
 	    CommandLine line = null;
@@ -322,6 +328,16 @@ public class Instrumenter {
 		Configuration.WITHOUT_BRANCH_NOT_TAKEN = line.hasOption("withoutBranchNotTaken");
 		Configuration.SKIP_LOCAL_VARIABLE_TABLE = line.hasOption("skipLocals");
 		Configuration.ALWAYS_CHECK_FOR_FRAMES = line.hasOption("alwaysCheckForFrames");
+
+		String priorClassVisitorName = line.getOptionValue(opt_priorClassVisitor.getOpt());
+		try {
+			@SuppressWarnings("unchecked")
+			Class<? extends ClassVisitor> temp = (Class<? extends ClassVisitor>)Class.forName(priorClassVisitorName);
+			Configuration.PRIOR_CLASS_VISITOR = temp;
+		} catch(Exception e) {
+			System.err.println("Failed to create specified prior class visitor: " + priorClassVisitorName);
+		}
+
 		Configuration.init();
 
 		

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/TaintUtils.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/TaintUtils.java
@@ -57,9 +57,10 @@ public class TaintUtils {
 	public static final int CUSTOM_SIGNAL_3 = 220;
 	public static final int LOOP_HEADER = 221;
 	public static final String TAINT_FIELD = "PHOSPHOR_TAG";
-	public static final String MARK_FIELD = "$$PHOSPHOR_MARK";
 	public static final String METHOD_SUFFIX = "$$PHOSPHORTAGGED";
-	public static final String ADDED_SVUID_SENTINEL = "$$PHOSPHOR_REMOVE_SVUID";
+	public static final String PHOSPHOR_ADDED_FIELD_PREFIX = "$$PHOSPHOR_";
+	public static final String MARK_FIELD = PHOSPHOR_ADDED_FIELD_PREFIX + "MARK";
+	public static final String ADDED_SVUID_SENTINEL = PHOSPHOR_ADDED_FIELD_PREFIX + "REMOVE_SVUID";
 //	public static final String HAS_TAINT_FIELD = "INVIVO_IS_TAINTED";
 //	public static final String IS_TAINT_SEATCHING_FIELD = "INVIVO_IS_TAINT_SEARCHING";
 	public static final boolean DEBUG_ALL = false;

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/ReflectionMasker.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/ReflectionMasker.java
@@ -1212,8 +1212,8 @@ public class ReflectionMasker {
 		ArrayList<Field> ret = new ArrayList<Field>();
 		boolean removeSVUIDField = containsSVUIDSentinelField(in);
 		for (Field f : in) {
-			if(!f.getName().equals("taint") && !f.getName().endsWith(TaintUtils.TAINT_FIELD) && !f.getName().equals(TaintUtils.ADDED_SVUID_SENTINEL)
-					&& !(removeSVUIDField && f.getName().equals("serialVersionUID")) && !f.getName().equals(TaintUtils.MARK_FIELD)) {
+			if(!f.getName().equals("taint") && !f.getName().endsWith(TaintUtils.TAINT_FIELD) && !f.getName().startsWith(TaintUtils.PHOSPHOR_ADDED_FIELD_PREFIX)
+					&& !(removeSVUIDField && f.getName().equals("serialVersionUID"))) {
 					/* && !f.getName().equals(TaintUtils.IS_TAINT_SEATCHING_FIELD) && !f.getName().equals(TaintUtils.HAS_TAINT_FIELD) */
 				ret.add(f);
 			}


### PR DESCRIPTION
… that should be masked during reflection

* Added priorClassVisitor Configuration option that allows a user to specify the class name of a ClassVisitor class to be added to Phosphor's visitor chain before taint tracking code is added to the class.