### PR TITLE
Hide added hash code

### DIFF
--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/ReflectionHidingMV.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/ReflectionHidingMV.java
@@ -242,7 +242,8 @@ public class ReflectionHidingMV extends MethodVisitor implements Opcodes {
 				if (!Configuration.WITHOUT_FIELD_HIDING)
 					super.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(ReflectionMasker.class), "removeTaintFields", "([Ljava/lang/reflect/Field;)[Ljava/lang/reflect/Field;", false);
 			} else if (owner.equals("java/lang/Class") && !className.equals(owner) &&  (desc.equals("()[Ljava/lang/reflect/Method;") || desc.equals("("+Type.getDescriptor(ControlTaintTagStack.class)+")[Ljava/lang/reflect/Method;"))) {
-					super.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(ReflectionMasker.class), "removeTaintMethods", "([Ljava/lang/reflect/Method;)[Ljava/lang/reflect/Method;", false);
+				super.visitInsn("getMethods".equals(name) ? ICONST_0 : ICONST_1);
+				super.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(ReflectionMasker.class), "removeTaintMethods", "([Ljava/lang/reflect/Method;Z)[Ljava/lang/reflect/Method;", false);
 			} else if (owner.equals("java/lang/Class") && !className.equals(owner) &&  (desc.equals("()[Ljava/lang/reflect/Constructor;") || desc.equals("("+Type.getDescriptor(ControlTaintTagStack.class)+")[Ljava/lang/reflect/Constructor;"))) {
 					super.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(ReflectionMasker.class), "removeTaintConstructors",
 							"([Ljava/lang/reflect/Constructor;)[Ljava/lang/reflect/Constructor;", false);

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/TaintTrackingClassVisitor.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/TaintTrackingClassVisitor.java
@@ -746,7 +746,7 @@ public class TaintTrackingClassVisitor extends ClassVisitor {
 			superMethodsToOverride.remove("hashCode()I");
 			methodsToAddWrappersFor.add(new MethodNode(Opcodes.ACC_PUBLIC | Opcodes.ACC_NATIVE, "hashCode", "()I", null, null));
 			MethodVisitor mv;
-			mv = super.visitMethod(Opcodes.ACC_PUBLIC, "hashCode", "()I", null, null);
+			mv = super.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_SYNTHETIC, "hashCode", "()I", null, null);
 			mv.visitCode();
 			Label start = new Label();
 			Label end = new Label();

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/UninstrumentedReflectionHidingMV.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/UninstrumentedReflectionHidingMV.java
@@ -148,7 +148,8 @@ public class UninstrumentedReflectionHidingMV extends MethodVisitor implements O
 		if (owner.equals("java/lang/Class") && desc.equals("()[Ljava/lang/reflect/Field;")) {
 				super.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(ReflectionMasker.class), "removeTaintFields", "([Ljava/lang/reflect/Field;)[Ljava/lang/reflect/Field;",false);
 		} else if (owner.equals("java/lang/Class") && desc.equals("()[Ljava/lang/reflect/Method;")) {
-				super.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(ReflectionMasker.class), "removeTaintMethods", "([Ljava/lang/reflect/Method;)[Ljava/lang/reflect/Method;",false);
+			super.visitInsn("getMethods".equals(name) ? ICONST_0 : ICONST_1);
+			super.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(ReflectionMasker.class), "removeTaintMethods", "([Ljava/lang/reflect/Method;Z)[Ljava/lang/reflect/Method;", false);
 		} else if (owner.equals("java/lang/Class") && desc.equals("()[Ljava/lang/reflect/Constructor;")) {
 				super.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(ReflectionMasker.class), "removeTaintConstructors",
 						"([Ljava/lang/reflect/Constructor;)[Ljava/lang/reflect/Constructor;",false);

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/ReflectionMasker.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/ReflectionMasker.java
@@ -1352,10 +1352,17 @@ public class ReflectionMasker {
 					}
 				else if(!matched)
 					ret.add(f);
-			} else if (!match) {
-				if(chars.length == 6 && chars[0] == 'e' && chars[1] == 'q'
-				&& chars[2] == 'u' && chars[3] == 'a' && chars[4] == 'l' && chars[5] == 's' && f.isSynthetic())
-					continue;
+			} else if(!match) {
+				// Check for synthetic hashCode and equals methods added by Phosphor
+				if(f.isSynthetic()) {
+					if(chars.length == 6 && chars[0] == 'e' && chars[1] == 'q' && chars[2] == 'u' && chars[3] == 'a' &&
+							chars[4] == 'l' && chars[5] == 's') {
+						continue;
+					} else if(chars.length == 8 && chars[0] == 'h' && chars[1] == 'a' && chars[2] == 's' && chars[3] == 'h' &&
+							chars[4] == 'C' && chars[5] == 'o' && chars[6] == 'd' && chars[7] == 'e') {
+						continue;
+					}
+				}
 				ret.add(f);
 			}
 		}

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/ReflectionMasker.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/ReflectionMasker.java
@@ -25,32 +25,31 @@ public class ReflectionMasker {
 
 	public static final boolean IS_KAFFE = false;
 
-	public static Class<?> getClassOOS(Object o)
-	{
+	public static Class<?> getClassOOS(Object o) {
 		if(o instanceof LazyArrayObjTags && ((LazyArrayObjTags) o).taints != null)
 			return o.getClass();
 		else if(o instanceof LazyArrayIntTags && ((LazyArrayIntTags) o).taints != null)
 			return o.getClass();
 		return removeTaintClass(o.getClass(), Configuration.MULTI_TAINTING);
 	}
-	public static Object getObject$$PHOSPHORTAGGED(Unsafe u, Object obj, Taint tag, long offset, ControlTaintTagStack ctrl)
-	{
+
+	public static Object getObject$$PHOSPHORTAGGED(Unsafe u, Object obj, Taint tag, long offset, ControlTaintTagStack ctrl) {
 		return MultiDTaintedArrayWithObjTag.boxIfNecessary(u.getObject(obj, offset));
 	}
-	public static Object getObject$$PHOSPHORTAGGED(Unsafe u, Object obj, Taint tag, long offset)
-	{
+
+	public static Object getObject$$PHOSPHORTAGGED(Unsafe u, Object obj, Taint tag, long offset) {
 		return MultiDTaintedArrayWithObjTag.boxIfNecessary(u.getObject(obj, offset));
 	}
-	public static Object getObject$$PHOSPHORTAGGED(Unsafe u, Object obj, int tag, long offset)
-	{
+
+	public static Object getObject$$PHOSPHORTAGGED(Unsafe u, Object obj, int tag, long offset) {
 		return MultiDTaintedArrayWithIntTag.boxIfNecessary(u.getObject(obj, offset));
 	}
-	public static void putObject$$PHOSPHORTAGGED(Unsafe u, Object obj, Taint tag, long fieldOffset, Object val, ControlTaintTagStack ctrl)
-	{
+
+	public static void putObject$$PHOSPHORTAGGED(Unsafe u, Object obj, Taint tag, long fieldOffset, Object val, ControlTaintTagStack ctrl) {
 		putObject$$PHOSPHORTAGGED(u, obj, tag, fieldOffset, val);
 	}
-	public static void putObject$$PHOSPHORTAGGED(Unsafe u, Object obj, int tag, long fieldOffset, Object val)
-	{
+
+	public static void putObject$$PHOSPHORTAGGED(Unsafe u, Object obj, int tag, long fieldOffset, Object val) {
 		//Need to put the actual obj if its a lazyarray and the offset points to the tag field
 		if(val instanceof LazyArrayIntTags)
 		{
@@ -83,8 +82,7 @@ public class ReflectionMasker {
 		u.putObject(obj, fieldOffset, val);
 	}
 
-	public static void putObject$$PHOSPHORTAGGED(Unsafe u, Object obj, Taint<?> tag, long fieldOffset, Object val)
-	{
+	public static void putObject$$PHOSPHORTAGGED(Unsafe u, Object obj, Taint<?> tag, long fieldOffset, Object val) {
 		//Need to put the actual obj if its a lazyarray and the offset points to the tag field
 		if(val instanceof LazyArrayObjTags)
 		{
@@ -117,8 +115,7 @@ public class ReflectionMasker {
 		u.putObject(obj, fieldOffset, val);
 	}
 	
-	private static void putTaintWrapper(Unsafe u, Field origField, Object obj, Object val)
-	{
+	private static void putTaintWrapper(Unsafe u, Field origField, Object obj, Object val) {
 		if(origField.getType().isArray() && origField.getType().getComponentType().isPrimitive())
 			try {
 				Field taintField = origField.getDeclaringClass().getDeclaredField(origField.getName()+TaintUtils.TAINT_FIELD);
@@ -128,11 +125,12 @@ public class ReflectionMasker {
 			}
 		
 	}
+
 	public static void putObjectVolatile$$PHOSPHORTAGGED(Unsafe u, Object obj, Taint<?> tag, long fieldOffset, Object val, ControlTaintTagStack ctrl){
 		putObjectVolatile$$PHOSPHORTAGGED(u, obj, tag, fieldOffset, val);
 	}
-	public static void putObjectVolatile$$PHOSPHORTAGGED(Unsafe u, Object obj, Taint<?> tag, long fieldOffset, Object val)
-	{
+
+	public static void putObjectVolatile$$PHOSPHORTAGGED(Unsafe u, Object obj, Taint<?> tag, long fieldOffset, Object val) {
 		//Need to put the actual obj if its a lazyarray and the offset points to the tag field
 		if(val instanceof LazyArrayObjTags)
 		{
@@ -165,7 +163,6 @@ public class ReflectionMasker {
 		u.putObjectVolatile(obj, fieldOffset, val);
 	}
 
-	
 	public static TaintedBooleanWithIntTag isInstance(Class<?> c1, Object o, TaintedBooleanWithIntTag ret) {
 		ret.taint = 0;
 		if (o instanceof LazyArrayIntTags || o instanceof LazyArrayIntTags[]) {
@@ -177,9 +174,11 @@ public class ReflectionMasker {
 			ret.val = c1.isInstance(o);
 		return ret;
 	}
+
 	public static TaintedBooleanWithObjTag isInstance(Class<?> c1, Object o, ControlTaintTagStack ctr, TaintedBooleanWithObjTag ret) {
 		return isInstance(c1, o, ret);
 	}
+
 	public static TaintedBooleanWithObjTag isInstance(Class<?> c1, Object o, TaintedBooleanWithObjTag ret) {
 		ret.taint = null;
 		if (o instanceof LazyArrayObjTags || o instanceof LazyArrayObjTags[]) {
@@ -191,6 +190,7 @@ public class ReflectionMasker {
 			ret.val = c1.isInstance(o);
 		return ret;
 	}
+
 	public static TaintedBooleanWithObjTag isInstanceOOS(Class<?> c1, Object o, TaintedBooleanWithObjTag ret) {
 		ret.taint = null;
 		if (o instanceof LazyArrayObjTags || o instanceof LazyArrayObjTags[]) {
@@ -202,6 +202,7 @@ public class ReflectionMasker {
 			ret.val = c1.isInstance(o);
 		return ret;
 	}
+
 	public static TaintedBooleanWithIntTag isInstanceOOS(Class<?> c1, Object o, TaintedBooleanWithIntTag ret) {
 		ret.taint = 0;
 		if (o instanceof LazyArrayIntTags || o instanceof LazyArrayIntTags[]) {
@@ -214,9 +215,7 @@ public class ReflectionMasker {
 		return ret;
 	}
 
-	
-	public static String getPropertyHideBootClasspath(String prop)
-	{
+	public static String getPropertyHideBootClasspath(String prop) {
 		if(prop.equals("sun.boot.class.path"))
 			return null;
 		else if(prop.equals("os.name"))
@@ -734,6 +733,7 @@ public class ReflectionMasker {
 	public static Method getDeclaredMethod(Class czz, String name, Class[] params, boolean isObjTags) throws NoSuchMethodException {
 		return czz.getDeclaredMethod(name, params);
 	}
+
 	public static Method getDeclaredMethod$$PHOSPHORTAGGED(Class czz, String name, Class[] params, ControlTaintTagStack ctrl) throws NoSuchMethodException {
 		return czz.getDeclaredMethod(name, params);
 	}
@@ -761,6 +761,7 @@ public class ReflectionMasker {
 		System.exit(-1);
 		return null;
 	}
+
 	public static Method getMethod(Class czz, String name, Class[] params, boolean isObjTags) throws NoSuchMethodException {
 		if (czz == Object.class || czz.isAnnotation() || Instrumenter.isIgnoredClass(czz.getName().replace('.', '/')))
 		    return czz.getMethod(name, params);
@@ -1317,58 +1318,81 @@ public class ReflectionMasker {
 	static final char[] FIELDSUFFIXCHARS = TaintUtils.TAINT_FIELD.toCharArray();
 	static final int FIELDSUFFIXLEN = FIELDSUFFIXCHARS.length;
 
-	public static Method[] removeTaintMethods(Method[] in) {
-		ArrayList<Method> ret = new ArrayList<Method>();
-		for (Method f : in) {
+	/* Called to mask Class.getDeclaredMethods and Class.getMethods. If declaredOnly is true then synthetic equals and
+	 * hashCode methods are fully remove from the specified array, otherwise they are replaced with Object.equals and
+	 * Object.hashCode respectively. */
+	@SuppressWarnings("unused")
+	public static Method[] removeTaintMethods(Method[] in, boolean declaredOnly) {
+		SinglyLinkedList<Method> ret = new SinglyLinkedList<>();
+		for(Method f : in) {
 			final char[] chars = f.getName().toCharArray();
 			boolean match = false;
-			if (chars.length == GETSETLEN) {
+			if(chars.length == GETSETLEN) {
 				match = true;
-				for (int i = 3; i < GETSETLEN; i++) {
-					if (chars[i] != GETSETCHARS[i]) {
+				for(int i = 3; i < GETSETLEN; i++) {
+					if(chars[i] != GETSETCHARS[i]) {
 						match = false;
 						break;
 					}
 				}
 			}
-			if (!match && chars.length > SUFFIX_LEN) {
+			if(!match && chars.length > SUFFIX_LEN) {
 				int x = 0;
 				boolean matched = true;
-				for (int i = chars.length - SUFFIX_LEN; i < chars.length; i++) {
-					if (chars[i] != SUFFIXCHARS[x]) {
+				for(int i = chars.length - SUFFIX_LEN; i < chars.length; i++) {
+					if(chars[i] != SUFFIXCHARS[x]) {
 						matched = false;
 						break;
 					}
 					x++;
 				}
 				x = 0;
-				if (!matched && Configuration.GENERATE_UNINST_STUBS && chars.length > SUFFIX_LEN + 2)
-					for (int i = chars.length - SUFFIX_LEN -2; i < chars.length; i++) {
-						if (chars[i] != SUFFIX2CHARS[x]) {
-							ret.add(f);
+				if(!matched && Configuration.GENERATE_UNINST_STUBS && chars.length > SUFFIX_LEN + 2)
+					for(int i = chars.length - SUFFIX_LEN -2; i < chars.length; i++) {
+						if(chars[i] != SUFFIX2CHARS[x]) {
+							ret.enqueue(f);
 							break;
 						}
 						x++;
 					}
 				else if(!matched)
-					ret.add(f);
+					ret.enqueue(f);
 			} else if(!match) {
 				// Check for synthetic hashCode and equals methods added by Phosphor
 				if(f.isSynthetic()) {
 					if(chars.length == 6 && chars[0] == 'e' && chars[1] == 'q' && chars[2] == 'u' && chars[3] == 'a' &&
 							chars[4] == 'l' && chars[5] == 's') {
+						if(!declaredOnly) {
+							ret.enqueue(ObjectMethods.EQUALS.method);
+						}
 						continue;
 					} else if(chars.length == 8 && chars[0] == 'h' && chars[1] == 'a' && chars[2] == 's' && chars[3] == 'h' &&
 							chars[4] == 'C' && chars[5] == 'o' && chars[6] == 'd' && chars[7] == 'e') {
+						if(!declaredOnly) {
+							ret.enqueue(ObjectMethods.HASH_CODE.method);
+						}
 						continue;
 					}
 				}
-				ret.add(f);
+				ret.enqueue(f);
 			}
 		}
-		Method[] retz = new Method[ret.size()];
-		ret.toArray(retz);
-		return retz;
+		return ret.toArray(new Method[ret.size()]);
+	}
+
+	/* Used to create singleton references to Methods of the Object class. */
+	private enum ObjectMethods {
+		EQUALS("equals", Object.class),
+		HASH_CODE("hashCode");
+
+		public Method method;
+		ObjectMethods(String name, Class<?>... parameterTypes) {
+			try {
+				this.method = Object.class.getDeclaredMethod(name, parameterTypes);
+			} catch(NoSuchMethodException e) {
+				e.printStackTrace();
+			}
+		}
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/SinglyLinkedList.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/SinglyLinkedList.java
@@ -177,7 +177,7 @@ public class SinglyLinkedList<E> implements Iterable<E>, Serializable {
     /* Returns an array containing the elements of this list. The runtime type of the returned array is that of the specified array. */
     @SuppressWarnings("unchecked")
     public E[] toArray(E[] arr) {
-        if (arr.length < size) {
+        if(arr.length < size) {
             arr = (E[]) Array.newInstance(arr.getClass().getComponentType(), size);
         }
         Node<E> cur = head;

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/ReflectionObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/ReflectionObjTagITCase.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 import org.junit.Test;
@@ -360,5 +361,18 @@ public class ReflectionObjTagITCase extends BasePhosphorTest {
 			}
 			assertTrue(methodMatchesExpected);
 		}
+	}
+
+	/* Checks that phosphor added equals and hashcode methods are replaced by Object.equals and Object.hashCode for
+	 * Class.getMethods. */
+	@Test
+	public void testHashCodeAndEqualsReplacedInGetMethods() throws NoSuchMethodException {
+		HashSet<Method> expected = new HashSet<>();
+		expected.add(MethodHolder.class.getDeclaredMethod("primitiveParamMethod", Boolean.TYPE));
+		expected.add(MethodHolder.class.getDeclaredMethod("primitiveArrParamMethod", boolean[].class));
+		expected.addAll(Arrays.asList(Object.class.getMethods()));
+		Method[] methods = MethodHolder.class.getMethods();
+		HashSet<Method> actual = new HashSet<>(Arrays.asList(methods));
+		assertEquals(expected, actual);
 	}
 }

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/ReflectionObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/ReflectionObjTagITCase.java
@@ -142,6 +142,7 @@ public class ReflectionObjTagITCase extends BasePhosphorTest {
 		assertNotNull(MultiTainter.getTaint(fh.z));
 
 	}
+
 	@Test
 	public void testRefArraySet() {
 		int[] arr = { 18 };
@@ -335,5 +336,29 @@ public class ReflectionObjTagITCase extends BasePhosphorTest {
 	public void testPrimitive2DArrayConstructorGetParamTypes() throws Exception {
 		Constructor<ConstructorHolder> cons = ConstructorHolder.class.getConstructor(boolean[][].class, boolean[].class, Boolean.TYPE);
 		assertArrayEquals(new Class<?>[]{boolean[][].class, boolean[].class, Boolean.TYPE}, cons.getParameterTypes());
+	}
+
+	/* Checks that phosphor added equals and hashcode methods are hidden from Class.getDeclaredMethods. */
+	@Test
+	public void testHashCodeAndEqualsHiddenFromGetDeclaredMethods() {
+		String[] methodNames = new String[]{"primitiveParamMethod", "primitiveArrParamMethod"};
+		Class<?>[] returnTypes = new Class<?>[]{Integer.TYPE, Integer.TYPE};
+		Class<?>[][] paramTypes = new Class<?>[][]{
+				new Class<?>[]{Boolean.TYPE},
+				new Class<?>[]{boolean[].class},
+		};
+		Method[] methods = MethodHolder.class.getDeclaredMethods();
+		assertEquals(2, methods.length);
+		for(Method method : methods) {
+			boolean methodMatchesExpected = false;
+			for(int i = 0; i < methodNames.length; i++) {
+				if(method.getName().equals(methodNames[i]) && method.getReturnType().equals(returnTypes[i])
+					&& Arrays.equals(method.getParameterTypes(), paramTypes[i])) {
+					methodMatchesExpected = true;
+					break;
+				}
+			}
+			assertTrue(methodMatchesExpected);
+		}
 	}
 }


### PR DESCRIPTION
* Made the hashCode methods added by phosphor to classes synthetic
* Changed ReflectionMasker to hide synthetic hashCode and equals methods for Class.getDeclaredMethods and to replace them for Class.getMethods
* Added previously failing test case to check that equals and hashCode methods added by phosphor are hidden  when calling Class.getDeclaredMethods
* Added previously failing test case to check that equals and hashCode methods added by phosphor are replaced by Object.equals and Object.hashCode when calling Class.getMethods