### PR TITLE
* Refactored method reflection tests

### DIFF
--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/runtime/FieldHolderBaseTest.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/runtime/FieldHolderBaseTest.java
@@ -1,15 +1,11 @@
 package edu.columbia.cs.psl.test.phosphor.runtime;
 
 import edu.columbia.cs.psl.phosphor.runtime.MultiTainter;
-import edu.columbia.cs.psl.phosphor.struct.IntObjectAMT;
 import edu.columbia.cs.psl.test.phosphor.BaseMultiTaintClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.ExternalResource;
-import sun.misc.Unsafe;
 
 import java.io.Serializable;
-import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -39,162 +35,6 @@ public abstract class FieldHolderBaseTest extends BaseMultiTaintClass {
             );
         }
     };
-
-    /* Supplies primitives and primitive arrays to a holder. */
-    public static class PrimitiveSupplier implements Serializable {
-
-        private static final long serialVersionUID = 8493043490151333333L;
-
-        private int i = 7;
-        private long j = 9L;
-        private boolean z = false;
-        private short s = 18;
-        private double d = 77.3;
-        private byte b = 1;
-        private char c = 'q';
-        private float f = 6.13f;
-
-        /* Returns an int that is tainted if taint is true. */
-        public int getInt(boolean taint) {
-            return taint ? MultiTainter.taintedInt(i, "int") : i;
-        }
-
-        /* Returns a long that is tainted if taint is true. */
-        public long getLong(boolean taint) {
-            return taint ? MultiTainter.taintedLong(j, "long") : j;
-        }
-
-        /* Returns a boolean that is tainted if taint is true. */
-        public boolean getBoolean(boolean taint) {
-            return taint ? MultiTainter.taintedBoolean(z, "boolean") : z;
-        }
-
-        /* Returns a short that is tainted if taint is true. */
-        public short getShort(boolean taint) {
-            return taint ? MultiTainter.taintedShort(s, "short") : s;
-        }
-
-        /* Returns a double that is tainted if taint is true. */
-        public double getDouble(boolean taint) {
-            return taint ? MultiTainter.taintedDouble(d, "double") : d;
-        }
-
-        /* Returns a byte that is tainted if taint is true. */
-        public byte getByte(boolean taint) {
-            return taint ? MultiTainter.taintedByte(b, "byte") : b;
-        }
-
-        /* Returns a char that is tainted if taint is true. */
-        public char getChar(boolean taint) {
-            return taint ? MultiTainter.taintedChar(c, "char") : c;
-        }
-
-        /* Returns a float that is tainted if taint is true. */
-        public float getFloat(boolean taint) {
-            return taint ? MultiTainter.taintedFloat(f, "float") : f;
-        }
-
-        /* Makes an array with the specified component type and number of dimensions. */
-        private static Object makeArray(Class<?> componentType, int dims) {
-            int[] lens = new int[dims];
-            for(int i = 0; i < dims; i++) {
-                lens[i] = 1;
-            }
-            return Array.newInstance(componentType, lens);
-        }
-
-        /* Returns the first 1D element of the specified array object. */
-        private static Object get1D(Object arr) {
-            while(arr.getClass().getComponentType().isArray()) {
-                arr = Array.get(arr, 0);
-            }
-            return arr;
-        }
-
-        /* Returns a int array with the specified number of dimensions whose elements are tainted if taint is true. */
-        public Object getIntArray(boolean taint, int dims) {
-            Object arr = makeArray(int.class, dims);
-            Array.setInt(get1D(arr), 0, getInt(taint));
-            return arr;
-        }
-
-        /* Returns a long array with the specified number of dimensions whose elements are tainted if taint is true. */
-        public Object getLongArray(boolean taint, int dims) {
-            Object arr = makeArray(long.class, dims);
-            Array.setLong(get1D(arr), 0, getLong(taint));
-            return arr;
-        }
-
-        /* Returns a boolean array with the specified number of dimensions whose elements are tainted if taint is true. */
-        public Object getBooleanArray(boolean taint, int dims) {
-            Object arr = makeArray(boolean.class, dims);
-            Array.setBoolean(get1D(arr), 0, getBoolean(taint));
-            return arr;
-        }
-
-        /* Returns a short array with the specified number of dimensions whose elements are tainted if taint is true. */
-        public Object getShortArray(boolean taint, int dims) {
-            Object arr = makeArray(short.class, dims);
-            Array.setShort(get1D(arr), 0, getShort(taint));
-            return arr;
-        }
-
-        /* Returns a double array with the specified number of dimensions whose elements are tainted if taint is true. */
-        public Object getDoubleArray(boolean taint, int dims) {
-            Object arr = makeArray(double.class, dims);
-            Array.setDouble(get1D(arr), 0, getDouble(taint));
-            return arr;
-        }
-
-        /* Returns a byte array with the specified number of dimensions whose elements are tainted if taint is true. */
-        public Object getByteArray(boolean taint, int dims) {
-            Object arr = makeArray(byte.class, dims);
-            Array.setByte(get1D(arr), 0, getByte(taint));
-            return arr;
-        }
-
-        /* Returns a char array with the specified number of dimensions whose elements are tainted if taint is true. */
-        public Object getCharArray(boolean taint, int dims) {
-            Object arr = makeArray(char.class, dims);
-            Array.setChar(get1D(arr), 0, getChar(taint));
-            return arr;
-        }
-
-        /* Returns a float array with the specified number of dimensions whose elements are tainted if taint is true. */
-        public Object getFloatArray(boolean taint, int dims) {
-            Object arr = makeArray(float.class, dims);
-            Array.setFloat(get1D(arr), 0, getFloat(taint));
-            return arr;
-        }
-
-        /* Returns given a multi-dimensional array type return an instance of the specified type whose elements are
-         * tainted if taint is true. */
-        public Object getArray(boolean taint, Class<?> clazz) {
-            int dims = 0;
-            for(; clazz.isArray(); clazz = clazz.getComponentType()) {
-                dims++;
-            }
-            if(boolean.class.equals(clazz)) {
-                return getBooleanArray(taint, dims);
-            } else if(byte.class.equals(clazz)) {
-                return getByteArray(taint, dims);
-            } else if(char.class.equals(clazz)) {
-                return getCharArray(taint, dims);
-            } else if(double.class.equals(clazz)) {
-                return getDoubleArray(taint, dims);
-            } else if(float.class.equals(clazz)) {
-                return getFloatArray(taint, dims);
-            } else if(int.class.equals(clazz)) {
-                return getIntArray(taint, dims);
-            } else if(long.class.equals(clazz)) {
-                return getLongArray(taint, dims);
-            } else if(short.class.equals(clazz)) {
-                return getShortArray(taint, dims);
-            } else {
-                return null;
-            }
-        }
-    }
 
     /* Holds primitive fields. */
     public static class PrimitiveHolder implements Serializable {

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/runtime/MethodHolder.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/runtime/MethodHolder.java
@@ -1,0 +1,37 @@
+package edu.columbia.cs.psl.test.phosphor.runtime;
+
+import edu.columbia.cs.psl.phosphor.runtime.MultiTainter;
+
+import static edu.columbia.cs.psl.test.phosphor.BaseMultiTaintClass.assertNonNullTaint;
+import static edu.columbia.cs.psl.test.phosphor.BaseMultiTaintClass.assertNullOrEmpty;
+
+@SuppressWarnings("unused")
+public class MethodHolder {
+
+    public static final int RET_VALUE = 2;
+
+    // Whether methods' arguments are expected to be tainted
+    private final boolean checkArgsTainted;
+
+    MethodHolder(boolean checkArgsTainted) {
+        this.checkArgsTainted = checkArgsTainted;
+    }
+
+    public int example(boolean taintedBool) {
+        if(checkArgsTainted) {
+            assertNonNullTaint(MultiTainter.getTaint(taintedBool));
+        } else {
+            assertNullOrEmpty(MultiTainter.getTaint(taintedBool));
+        }
+        return RET_VALUE;
+    }
+
+    public int example(boolean[] b) {
+        if(checkArgsTainted) {
+            assertNonNullTaint(MultiTainter.getTaint(b[0]));
+        } else {
+            assertNullOrEmpty(MultiTainter.getTaint(b[0]));
+        }
+        return RET_VALUE;
+    }
+}

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/runtime/MethodReflectionImplicitITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/runtime/MethodReflectionImplicitITCase.java
@@ -1,0 +1,4 @@
+package edu.columbia.cs.psl.test.phosphor.runtime;
+
+public class MethodReflectionImplicitITCase extends MethodReflectionObjTagITCase {
+}

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/runtime/MethodReflectionObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/runtime/MethodReflectionObjTagITCase.java
@@ -1,0 +1,149 @@
+package edu.columbia.cs.psl.test.phosphor.runtime;
+
+import edu.columbia.cs.psl.test.phosphor.BaseMultiTaintClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.rules.ExternalResource;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.junit.Assert.*;
+
+@RunWith(Enclosed.class)
+public class MethodReflectionObjTagITCase extends BaseMultiTaintClass {
+
+    private static PrimitiveSupplier supplier;
+
+    @ClassRule
+    public static ExternalResource resource = new ExternalResource() {
+        @Override
+        protected void before() {
+            supplier = new PrimitiveSupplier();
+        }
+    };
+
+    @RunWith(Theories.class)
+    public static class MethodInvokeTheoryTests {
+
+        @DataPoints
+        public static Class<?>[][] types = new Class<?>[][] {
+                {Boolean.TYPE},
+                {boolean[].class}
+        };
+
+        @DataPoints
+        public static Boolean[] taintArguments = new Boolean[]{true, false};
+
+        /* Invokes a method using reflection. Checks that the invocation succeeded and returned an expected value.
+         * Checks that any taint tags associated with the arguments are also passed to the method call. */
+        @Theory
+        public void testInvokeMethod(Boolean taintArguments, Class<?>[] types) throws Exception {
+            MethodHolder holder = new MethodHolder(taintArguments);
+            Method method = MethodHolder.class.getMethod("example", types);
+            Object[] args = new Object[types.length];
+            for(int i = 0; i < types.length; i++) {
+                args[i] = types[i].isArray() ? supplier.getArray(taintArguments, types[i]) : supplier.getBoxedPrimitive(taintArguments, types[i]);
+            }
+            Object result = method.invoke(holder, args);
+            assertTrue("Expected integer to be returned from reflected method.", result instanceof Integer);
+            int i = (Integer)result;
+            assertEquals(MethodHolder.RET_VALUE, i);
+        }
+    }
+
+    public static class StandardTests {
+
+        /* Checks that parameters passed to getDeclaredMethod and invoke for ignored classes like Boolean are not
+         * remapped. */
+        @Test
+        public void testBooleanIgnoredMethod() throws Exception {
+            Method method = Boolean.class.getDeclaredMethod("toString", boolean.class);
+            String result = (String)method.invoke(null, false);
+            assertNotNull(result);
+        }
+
+        /* Checks that a NoSuchMethodException is thrown for classes which do not declare an equals method even if a
+         * synthetic one was added by Phosphor. */
+        @Test(expected = NoSuchMethodException.class)
+        public void testGetDeclaredMethodEquals() throws NoSuchMethodException {
+            MethodHolder.class.getDeclaredMethod("equals", Object.class);
+        }
+
+        /* Checks that a NoSuchMethodException is thrown for classes which do not declare a hashCode method even if a
+         * synthetic one was added by Phosphor. */
+        @Test(expected = NoSuchMethodException.class)
+        public void testGetDeclaredMethodHashCode() throws NoSuchMethodException {
+            MethodHolder.class.getDeclaredMethod("hashCode");
+        }
+
+        /* Checks that a class' original equals method is returned by Class.getMethod even if a synthetic one was added
+         * by Phosphor. */
+        @Test
+        public void testGetMethodEquals() throws NoSuchMethodException {
+            Method actual = MethodHolder.class.getMethod("equals", Object.class);
+            Method expected = Object.class.getMethod("equals", Object.class);
+            assertEquals(expected, actual);
+        }
+
+        /* Checks that a class' original hashCode method is returned by Class.getMethod even if a synthetic one was added
+         * by Phosphor. */
+        @Test
+        public void testGetMethodHashCode() throws NoSuchMethodException {
+            Method actual = MethodHolder.class.getMethod("hashCode");
+            Method expected = Object.class.getMethod("hashCode");
+            assertEquals(expected, actual);
+        }
+
+        /* Checks that synthetic equals and hashcode methods added by Phosphor are replaced by Object.equals and
+         * Object.hashCode for Class.getMethods. */
+        @Test
+        public void testHashCodeAndEqualsReplacedInGetMethods() throws NoSuchMethodException {
+            HashSet<Method> expected = new HashSet<>();
+            expected.add(MethodHolder.class.getDeclaredMethod("example", Boolean.TYPE));
+            expected.add(MethodHolder.class.getDeclaredMethod("example", boolean[].class));
+            expected.addAll(Arrays.asList(Object.class.getMethods()));
+            Method[] methods = MethodHolder.class.getMethods();
+            HashSet<Method> actual = new HashSet<>(Arrays.asList(methods));
+            assertEquals(expected, actual);
+        }
+
+        /* Checks that synthetic equals and hashcode methods added by Phosphor are hidden from Class.getDeclaredMethods. */
+        @Test
+        public void testHashCodeAndEqualsHiddenFromGetDeclaredMethods() {
+            String[] methodNames = new String[]{"example", "example"};
+            Class<?>[] returnTypes = new Class<?>[]{Integer.TYPE, Integer.TYPE};
+            Class<?>[][] paramTypes = new Class<?>[][]{
+                    new Class<?>[]{Boolean.TYPE},
+                    new Class<?>[]{boolean[].class},
+            };
+            Method[] methods = MethodHolder.class.getDeclaredMethods();
+            assertEquals(2, methods.length);
+            for(Method method : methods) {
+                boolean methodMatchesExpected = false;
+                for(int i = 0; i < methodNames.length; i++) {
+                    if(method.getName().equals(methodNames[i]) && method.getReturnType().equals(returnTypes[i])
+                            && Arrays.equals(method.getParameterTypes(), paramTypes[i])) {
+                        methodMatchesExpected = true;
+                        break;
+                    }
+                }
+                assertTrue(methodMatchesExpected);
+            }
+        }
+
+        /* Checks that the methods returned by getMethod and getDeclaredMethod are equal. */
+        @Test
+        public void testGetMethodEqualsGetDeclaredMethod() throws NoSuchMethodException {
+            Method m = MethodHolder.class.getMethod("example", Boolean.TYPE);
+            Method mDeclared = MethodHolder.class.getDeclaredMethod("example", Boolean.TYPE);
+            assertEquals(mDeclared, m);
+        }
+    }
+}

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/runtime/PrimitiveSupplier.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/runtime/PrimitiveSupplier.java
@@ -1,0 +1,185 @@
+package edu.columbia.cs.psl.test.phosphor.runtime;
+
+import edu.columbia.cs.psl.phosphor.runtime.MultiTainter;
+
+import java.io.Serializable;
+import java.lang.reflect.Array;
+
+/* Supplies primitives and primitive arrays to a holder. */
+public class PrimitiveSupplier implements Serializable {
+
+    private static final long serialVersionUID = 8493043490151333333L;
+
+    private int i = 7;
+    private long j = 9L;
+    private boolean z = false;
+    private short s = 18;
+    private double d = 77.3;
+    private byte b = 1;
+    private char c = 'q';
+    private float f = 6.13f;
+
+    /* Returns an int that is tainted if taint is true. */
+    public int getInt(boolean taint) {
+        return taint ? MultiTainter.taintedInt(i, "int") : i;
+    }
+
+    /* Returns a long that is tainted if taint is true. */
+    public long getLong(boolean taint) {
+        return taint ? MultiTainter.taintedLong(j, "long") : j;
+    }
+
+    /* Returns a boolean that is tainted if taint is true. */
+    public boolean getBoolean(boolean taint) {
+        return taint ? MultiTainter.taintedBoolean(z, "boolean") : z;
+    }
+
+    /* Returns a short that is tainted if taint is true. */
+    public short getShort(boolean taint) {
+        return taint ? MultiTainter.taintedShort(s, "short") : s;
+    }
+
+    /* Returns a double that is tainted if taint is true. */
+    public double getDouble(boolean taint) {
+        return taint ? MultiTainter.taintedDouble(d, "double") : d;
+    }
+
+    /* Returns a byte that is tainted if taint is true. */
+    public byte getByte(boolean taint) {
+        return taint ? MultiTainter.taintedByte(b, "byte") : b;
+    }
+
+    /* Returns a char that is tainted if taint is true. */
+    public char getChar(boolean taint) {
+        return taint ? MultiTainter.taintedChar(c, "char") : c;
+    }
+
+    /* Returns a float that is tainted if taint is true. */
+    public float getFloat(boolean taint) {
+        return taint ? MultiTainter.taintedFloat(f, "float") : f;
+    }
+
+    /* Makes an array with the specified component type and number of dimensions. */
+    private static Object makeArray(Class<?> componentType, int dims) {
+        int[] lens = new int[dims];
+        for(int i = 0; i < dims; i++) {
+            lens[i] = 1;
+        }
+        return Array.newInstance(componentType, lens);
+    }
+
+    /* Returns the first 1D element of the specified array object. */
+    private static Object get1D(Object arr) {
+        while(arr.getClass().getComponentType().isArray()) {
+            arr = Array.get(arr, 0);
+        }
+        return arr;
+    }
+
+    /* Returns a int array with the specified number of dimensions whose elements are tainted if taint is true. */
+    public Object getIntArray(boolean taint, int dims) {
+        Object arr = makeArray(int.class, dims);
+        Array.setInt(get1D(arr), 0, getInt(taint));
+        return arr;
+    }
+
+    /* Returns a long array with the specified number of dimensions whose elements are tainted if taint is true. */
+    public Object getLongArray(boolean taint, int dims) {
+        Object arr = makeArray(long.class, dims);
+        Array.setLong(get1D(arr), 0, getLong(taint));
+        return arr;
+    }
+
+    /* Returns a boolean array with the specified number of dimensions whose elements are tainted if taint is true. */
+    public Object getBooleanArray(boolean taint, int dims) {
+        Object arr = makeArray(boolean.class, dims);
+        Array.setBoolean(get1D(arr), 0, getBoolean(taint));
+        return arr;
+    }
+
+    /* Returns a short array with the specified number of dimensions whose elements are tainted if taint is true. */
+    public Object getShortArray(boolean taint, int dims) {
+        Object arr = makeArray(short.class, dims);
+        Array.setShort(get1D(arr), 0, getShort(taint));
+        return arr;
+    }
+
+    /* Returns a double array with the specified number of dimensions whose elements are tainted if taint is true. */
+    public Object getDoubleArray(boolean taint, int dims) {
+        Object arr = makeArray(double.class, dims);
+        Array.setDouble(get1D(arr), 0, getDouble(taint));
+        return arr;
+    }
+
+    /* Returns a byte array with the specified number of dimensions whose elements are tainted if taint is true. */
+    public Object getByteArray(boolean taint, int dims) {
+        Object arr = makeArray(byte.class, dims);
+        Array.setByte(get1D(arr), 0, getByte(taint));
+        return arr;
+    }
+
+    /* Returns a char array with the specified number of dimensions whose elements are tainted if taint is true. */
+    public Object getCharArray(boolean taint, int dims) {
+        Object arr = makeArray(char.class, dims);
+        Array.setChar(get1D(arr), 0, getChar(taint));
+        return arr;
+    }
+
+    /* Returns a float array with the specified number of dimensions whose elements are tainted if taint is true. */
+    public Object getFloatArray(boolean taint, int dims) {
+        Object arr = makeArray(float.class, dims);
+        Array.setFloat(get1D(arr), 0, getFloat(taint));
+        return arr;
+    }
+
+    /* Returns an instance of the specified multi-dimensional primitive array type whose elements are tainted if taint is true. */
+    public Object getArray(boolean taint, Class<?> clazz) {
+        int dims = 0;
+        for(; clazz.isArray(); clazz = clazz.getComponentType()) {
+            dims++;
+        }
+        if(boolean.class.equals(clazz)) {
+            return getBooleanArray(taint, dims);
+        } else if(byte.class.equals(clazz)) {
+            return getByteArray(taint, dims);
+        } else if(char.class.equals(clazz)) {
+            return getCharArray(taint, dims);
+        } else if(double.class.equals(clazz)) {
+            return getDoubleArray(taint, dims);
+        } else if(float.class.equals(clazz)) {
+            return getFloatArray(taint, dims);
+        } else if(int.class.equals(clazz)) {
+            return getIntArray(taint, dims);
+        } else if(long.class.equals(clazz)) {
+            return getLongArray(taint, dims);
+        } else if(short.class.equals(clazz)) {
+            return getShortArray(taint, dims);
+        } else {
+            throw new RuntimeException("getArray expects multi-dimensional primitive array type.");
+        }
+    }
+
+    /* Returns an instance of the specified boxed primitive type or a boxed instance of the specified primitive type that
+     * is tainted if taint is true. */
+    public Object getBoxedPrimitive(boolean taint, Class<?> clazz) {
+        if(boolean.class.equals(clazz) || Boolean.class.equals(clazz)) {
+            return getBoolean(taint);
+        } else if(byte.class.equals(clazz) || Byte.class.equals(clazz)) {
+            return getByte(taint);
+        } else if(char.class.equals(clazz) || Character.class.equals(clazz)) {
+            return getChar(taint);
+        } else if(double.class.equals(clazz) || Double.class.equals(clazz)) {
+            return getDouble(taint);
+        } else if(float.class.equals(clazz) || Float.class.equals(clazz)) {
+            return getFloat(taint);
+        } else if(int.class.equals(clazz) || Integer.class.equals(clazz)) {
+            return getInt(taint);
+        } else if(long.class.equals(clazz) || Long.class.equals(clazz)) {
+            return getLong(taint);
+        } else if(short.class.equals(clazz) || Short.class.equals(clazz)) {
+            return getShort(taint);
+        } else {
+            throw new RuntimeException("getBoxedPrimitive expects primitive or boxed primitive type.");
+        }
+    }
+}


### PR DESCRIPTION
* Added tests that Class.getDeclaredMethod and Class.getMethod do not return synthetic equals and hashCode methods added by Phosphor
* Masked Class.getDeclaredMethod and Class.getMethod to ensure that they do not return synthetic equals and hashCode methods added by Phosphor
* Changed "masking" of getMethod to match getDeclaredMethod
* Fixes #124 