### PR TITLE
Boxing and Serialization fixes

### DIFF
--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/PreMain.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/PreMain.java
@@ -277,6 +277,9 @@ public class PreMain {
 					}
 					if (DEBUG || TaintUtils.VERIFY_CLASS_GENERATION)
 						_cv = new CheckClassAdapter(_cv, false);
+					if(SerializationFixingCV.isApplicable(className)) {
+						_cv = new SerializationFixingCV(_cv);
+					}
                     _cv = new ClinitRetransformClassVisitor(_cv);
 					if(isiFace)
 						_cv = new TaintTrackingClassVisitor(_cv, skipFrames, fields);

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/PreMain.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/PreMain.java
@@ -278,7 +278,7 @@ public class PreMain {
 					if (DEBUG || TaintUtils.VERIFY_CLASS_GENERATION)
 						_cv = new CheckClassAdapter(_cv, false);
 					if(SerializationFixingCV.isApplicable(className)) {
-						_cv = new SerializationFixingCV(_cv);
+						_cv = new SerializationFixingCV(_cv, className);
 					}
                     _cv = new ClinitRetransformClassVisitor(_cv);
 					if(isiFace)

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/SerializationFixingCV.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/SerializationFixingCV.java
@@ -13,6 +13,7 @@ public class SerializationFixingCV extends ClassVisitor implements Opcodes {
     private static final String INPUT_STREAM_NAME = "java/io/ObjectInputStream";
     // ObjectOutputStream class name
     private static final String OUTPUT_STREAM_NAME = "java/io/ObjectOutputStream";
+    private final static byte TC_OBJECT = (byte)0x73;
 
     public SerializationFixingCV(ClassVisitor cv) {
         super(Configuration.ASM_VERSION, cv);
@@ -35,8 +36,111 @@ public class SerializationFixingCV extends ClassVisitor implements Opcodes {
             case "readObject$$PHOSPHORTAGGED":
             case "readObject0$$PHOSPHORTAGGED":
                 return new ObjectReadMV(mv);
+            case "writeInt$$PHOSPHORTAGGED":
+            case "writeLong$$PHOSPHORTAGGED":
+            case "writeBoolean$$PHOSPHORTAGGED":
+            case "writeShort$$PHOSPHORTAGGED":
+            case "writeDouble$$PHOSPHORTAGGED":
+            case "writeByte$$PHOSPHORTAGGED":
+            case "writeChar$$PHOSPHORTAGGED":
+            case "writeFloat$$PHOSPHORTAGGED":
+                return new PrimitiveWriteMV(mv);
+            case "readInt$$PHOSPHORTAGGED":
+            case "readLong$$PHOSPHORTAGGED":
+            case "readBoolean$$PHOSPHORTAGGED":
+            case "readShort$$PHOSPHORTAGGED":
+            case "readDouble$$PHOSPHORTAGGED":
+            case "readByte$$PHOSPHORTAGGED":
+            case "readChar$$PHOSPHORTAGGED":
+            case "readFloat$$PHOSPHORTAGGED":
+            case "readUnsignedByte$$PHOSPHORTAGGED":
+            case "readUnsignedShort$$PHOSPHORTAGGED":
+                return new PrimitiveReadMV(mv, Type.getReturnType(desc));
             default:
                 return mv;
+        }
+    }
+
+    private static class PrimitiveWriteMV extends MethodVisitor {
+
+        PrimitiveWriteMV(MethodVisitor mv) {
+            super(Configuration.ASM_VERSION, mv);
+        }
+
+        @Override
+        public void visitCode() {
+            super.visitCode();
+            super.visitVarInsn(ALOAD, 0);
+            super.visitVarInsn(ALOAD, 1); // Load taint onto stack
+            super.visitMethodInsn(INVOKEVIRTUAL, OUTPUT_STREAM_NAME, "writeObject", "(Ljava/lang/Object;)V", false);
+        }
+    }
+
+    private static class PrimitiveReadMV extends MethodVisitor {
+
+        private final Type returnType;
+
+        PrimitiveReadMV(MethodVisitor mv, Type returnType) {
+            super(Configuration.ASM_VERSION, mv);
+            this.returnType = returnType;
+        }
+
+        @Override
+        public void visitCode() {
+            super.visitCode();
+            Label label1 = new Label();
+            Label label2 = new Label();
+            Label label3 = new Label();
+            super.visitVarInsn(ALOAD, 0);
+            super.visitFieldInsn(GETFIELD, INPUT_STREAM_NAME, "bin", "Ljava/io/ObjectInputStream$BlockDataInputStream;");
+            super.visitMethodInsn(INVOKEVIRTUAL, "java/io/ObjectInputStream$BlockDataInputStream", "getBlockDataMode", "()Z", false);
+            super.visitJumpInsn(IFEQ, label1);
+            //
+            super.visitVarInsn(ALOAD, 0);
+            super.visitFieldInsn(GETFIELD, INPUT_STREAM_NAME, "bin", "Ljava/io/ObjectInputStream$BlockDataInputStream;");
+            super.visitMethodInsn(INVOKEVIRTUAL, "java/io/ObjectInputStream$BlockDataInputStream", "currentBlockRemaining", "()I", false);
+            super.visitJumpInsn(IFNE, label2);
+            // Get current value of block data mode
+            super.visitLabel(label1);
+            super.visitVarInsn(ALOAD, 0);
+            super.visitFieldInsn(GETFIELD, INPUT_STREAM_NAME, "bin", "Ljava/io/ObjectInputStream$BlockDataInputStream;");
+            super.visitInsn(DUP);
+            super.visitMethodInsn(INVOKEVIRTUAL, "java/io/ObjectInputStream$BlockDataInputStream", "getBlockDataMode", "()Z", false);
+            // Set block data mode to false
+            super.visitVarInsn(ALOAD, 0);
+            super.visitFieldInsn(GETFIELD, INPUT_STREAM_NAME, "bin", "Ljava/io/ObjectInputStream$BlockDataInputStream;");
+            super.visitInsn(ICONST_0);
+            super.visitMethodInsn(INVOKEVIRTUAL, "java/io/ObjectInputStream$BlockDataInputStream", "setBlockDataMode", "(Z)Z", false);
+            super.visitInsn(POP);
+            // Peek at next byte
+            super.visitVarInsn(ALOAD, 0);
+            super.visitFieldInsn(GETFIELD, INPUT_STREAM_NAME, "bin", "Ljava/io/ObjectInputStream$BlockDataInputStream;");
+            super.visitMethodInsn(INVOKEVIRTUAL, "java/io/ObjectInputStream$BlockDataInputStream", "peek", "()I", false);
+            // Restore previous block data mode
+            super.visitInsn(DUP_X2);
+            super.visitInsn(POP);
+            super.visitMethodInsn(INVOKEVIRTUAL, "java/io/ObjectInputStream$BlockDataInputStream", "setBlockDataMode", "(Z)Z", false);
+            super.visitInsn(POP);
+            // Compare next byte to byte for objects
+            super.visitIntInsn(BIPUSH, TC_OBJECT);
+            super.visitJumpInsn(IF_ICMPNE, label2);
+            super.visitVarInsn(ALOAD, 0);
+            super.visitMethodInsn(INVOKEVIRTUAL, INPUT_STREAM_NAME, "readObject", "()Ljava/lang/Object;", false);
+            super.visitTypeInsn(CHECKCAST, Type.getType(Configuration.TAINT_TAG_DESC).getInternalName());
+            super.visitJumpInsn(GOTO, label3);
+            super.visitLabel(label2);
+            super.visitInsn(ACONST_NULL);
+            super.visitLabel(label3);
+        }
+
+        @Override
+        public void visitInsn(int opcode) {
+            if(TaintUtils.isReturnOpcode(opcode)) {
+                super.visitInsn(DUP_X1);
+                super.visitInsn(SWAP);
+                super.visitFieldInsn(PUTFIELD, returnType.getInternalName(), "taint", "Ledu/columbia/cs/psl/phosphor/runtime/Taint;");
+            }
+            super.visitInsn(opcode);
         }
     }
 

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/SerializationFixingCV.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/SerializationFixingCV.java
@@ -1,0 +1,97 @@
+package edu.columbia.cs.psl.phosphor.instrumenter;
+
+import edu.columbia.cs.psl.phosphor.Configuration;
+import edu.columbia.cs.psl.phosphor.TaintUtils;
+import edu.columbia.cs.psl.phosphor.runtime.MultiTainter;
+import edu.columbia.cs.psl.phosphor.runtime.Taint;
+import edu.columbia.cs.psl.phosphor.struct.SerializationWrapper;
+import org.objectweb.asm.*;
+
+public class SerializationFixingCV extends ClassVisitor implements Opcodes {
+
+    // ObjectInputStream class name
+    private static final String INPUT_STREAM_NAME = "java/io/ObjectInputStream";
+    // ObjectOutputStream class name
+    private static final String OUTPUT_STREAM_NAME = "java/io/ObjectOutputStream";
+
+    public SerializationFixingCV(ClassVisitor cv) {
+        super(Configuration.ASM_VERSION, cv);
+    }
+
+    /* Returns whether this class visitor should be applied to the class with the specified name. */
+    public static boolean isApplicable(String className) {
+        return Configuration.MULTI_TAINTING && (INPUT_STREAM_NAME.equals(className) || OUTPUT_STREAM_NAME.equals(className));
+    }
+
+    @Override
+    public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+        MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
+        switch(name) {
+            case "writeObject":
+            case "writeObject$$PHOSPHORTAGGED":
+            case "writeObject0$$PHOSPHORTAGGED":
+                return new ObjectWriteMV(mv);
+            case "readObject":
+            case "readObject$$PHOSPHORTAGGED":
+            case "readObject0$$PHOSPHORTAGGED":
+                return new ObjectReadMV(mv);
+            default:
+                return mv;
+        }
+    }
+
+    private static class ObjectWriteMV extends MethodVisitor {
+
+        ObjectWriteMV(MethodVisitor mv) {
+            super(Configuration.ASM_VERSION, mv);
+        }
+
+        @Override
+        public void visitCode() {
+            super.visitCode();
+            super.visitVarInsn(ALOAD, 1);
+            super.visitMethodInsn(INVOKESTATIC, Type.getInternalName(SerializationFixingCV.class), "wrapIfNecessary", "(Ljava/lang/Object;)Ljava/lang/Object;", false);
+            super.visitVarInsn(ASTORE, 1);
+        }
+    }
+
+    private static class ObjectReadMV extends MethodVisitor {
+
+        ObjectReadMV(MethodVisitor mv) {
+            super(Configuration.ASM_VERSION, mv);
+        }
+
+        @Override
+        public void visitInsn(int opcode) {
+            if(TaintUtils.isReturnOpcode(opcode)) {
+                super.visitMethodInsn(INVOKESTATIC, Type.getInternalName(SerializationFixingCV.class), "unwrapIfNecessary", "(Ljava/lang/Object;)Ljava/lang/Object;", false);
+            }
+            super.visitInsn(opcode);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static Object wrapIfNecessary(Object obj) {
+        Taint tag = MultiTainter.getTaint(obj);
+        if(tag != null && !tag.isEmpty()) {
+            if(obj instanceof Boolean) {
+                return SerializationWrapper.wrap((Boolean) obj);
+            } else if(obj instanceof Byte) {
+                return SerializationWrapper.wrap((Byte) obj);
+            } else if(obj instanceof Character) {
+                return SerializationWrapper.wrap((Character) obj);
+            } else if(obj instanceof Short) {
+                return SerializationWrapper.wrap((Short) obj);
+            }
+        }
+        return obj;
+    }
+
+    @SuppressWarnings("unused")
+    public static Object unwrapIfNecessary(Object obj) {
+        if(obj instanceof SerializationWrapper) {
+            return ((SerializationWrapper)obj).unwrap();
+        }
+        return obj;
+    }
+}

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/SerializationFixingCV.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/SerializationFixingCV.java
@@ -147,7 +147,7 @@ public class SerializationFixingCV extends ClassVisitor implements Opcodes {
             super.visitLabel(label5);
             super.visitVarInsn(ALOAD, 0);
             super.visitMethodInsn(INVOKEVIRTUAL, INPUT_STREAM_NAME, "readObject", "()Ljava/lang/Object;", false);
-            super.visitTypeInsn(CHECKCAST, Type.getType(Configuration.TAINT_TAG_DESC).getInternalName());
+            super.visitTypeInsn(CHECKCAST,  Configuration.TAINT_TAG_INTERNAL_NAME);
             super.visitJumpInsn(GOTO, label3);
             // Push null onto stack
             super.visitLabel(label2);
@@ -160,7 +160,7 @@ public class SerializationFixingCV extends ClassVisitor implements Opcodes {
             if(TaintUtils.isReturnOpcode(opcode)) {
                 super.visitInsn(DUP_X1);
                 super.visitInsn(SWAP);
-                super.visitFieldInsn(PUTFIELD, returnType.getInternalName(), "taint", "Ledu/columbia/cs/psl/phosphor/runtime/Taint;");
+                super.visitFieldInsn(PUTFIELD, returnType.getInternalName(), "taint", Configuration.TAINT_TAG_DESC);
             }
             super.visitInsn(opcode);
         }

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/TaintTrackingClassVisitor.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/instrumenter/TaintTrackingClassVisitor.java
@@ -1518,8 +1518,7 @@ public class TaintTrackingClassVisitor extends ClassVisitor {
 					for(int i = 0; i < args.length; i++)
 					{
 						ga.loadArg(i);
-						if(args[i].getSort() == Type.ARRAY && args[i].getDimensions() >1&&args[i].getElementType().getSort() != Type.OBJECT)
-						{
+						if(args[i].getSort() == Type.ARRAY && args[i].getDimensions() >1&&args[i].getElementType().getSort() != Type.OBJECT) {
 							ga.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName((Configuration.MULTI_TAINTING ? MultiDTaintedArrayWithObjTag.class : MultiDTaintedArrayWithIntTag.class)), "unboxRaw", "(Ljava/lang/Object;)Ljava/lang/Object;",false);
 							ga.visitTypeInsn(Opcodes.CHECKCAST, args[i].getInternalName());
 						}
@@ -1866,10 +1865,15 @@ public class TaintTrackingClassVisitor extends ClassVisitor {
 						if (isUntaggedCall)
 							ga.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(MultiDTaintedArray.class), "unbox1D", "(Ljava/lang/Object;)Ljava/lang/Object;", false);
 						else {
-							if (className.equals("sun/misc/Unsafe"))
+							if(className.equals("sun/misc/Unsafe")) {
 								ga.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName((Configuration.MULTI_TAINTING ? MultiDTaintedArrayWithObjTag.class : MultiDTaintedArrayWithIntTag.class)), "unboxRawOnly1D", "(Ljava/lang/Object;)Ljava/lang/Object;", false);
-							else
+							} else if(className.equals("sun/reflect/NativeMethodAccessorImpl") && "invoke0".equals(methodNameToCall) && Type.getType(Object.class).equals(t)) {
+								ga.loadArg(0);
+								ga.visitInsn(Opcodes.SWAP);
+								ga.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(MultiDTaintedArray.class), "unboxMethodReceiverIfNecessary", "(Ljava/lang/reflect/Method;Ljava/lang/Object;)Ljava/lang/Object;", false);
+							} else {
 								ga.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName((Configuration.MULTI_TAINTING ? MultiDTaintedArrayWithObjTag.class : MultiDTaintedArrayWithIntTag.class)), "unboxRaw", "(Ljava/lang/Object;)Ljava/lang/Object;", false);
+							}
 						}
 						if (t.getSort() == Type.ARRAY)
 							ga.visitTypeInsn(Opcodes.CHECKCAST, t.getInternalName());

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/BoxedPrimitiveStoreWithObjTags.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/runtime/BoxedPrimitiveStoreWithObjTags.java
@@ -1,14 +1,10 @@
 package edu.columbia.cs.psl.phosphor.runtime;
 
-import java.util.WeakHashMap;
-
-import edu.columbia.cs.psl.phosphor.struct.TaintedBooleanWithObjTag;
-import edu.columbia.cs.psl.phosphor.struct.TaintedByteWithObjTag;
-import edu.columbia.cs.psl.phosphor.struct.TaintedCharWithObjTag;
-import edu.columbia.cs.psl.phosphor.struct.TaintedShortWithObjTag;
+import edu.columbia.cs.psl.phosphor.struct.*;
 
 public class BoxedPrimitiveStoreWithObjTags {
-	public static WeakHashMap<Object, Taint> tags = new WeakHashMap<Object, Taint>();
+
+	public static WeakIdentityHashMap<Object, Taint> tags = new WeakIdentityHashMap<>();
 
 	public static TaintedBooleanWithObjTag booleanValue(Boolean z) {
 		TaintedBooleanWithObjTag ret = new TaintedBooleanWithObjTag();

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/SerializationWrapper.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/SerializationWrapper.java
@@ -1,0 +1,99 @@
+package edu.columbia.cs.psl.phosphor.struct;
+
+import edu.columbia.cs.psl.phosphor.runtime.BoxedPrimitiveStoreWithObjTags;
+import edu.columbia.cs.psl.phosphor.runtime.MultiTainter;
+import edu.columbia.cs.psl.phosphor.runtime.Taint;
+
+import java.io.Serializable;
+
+public abstract class SerializationWrapper implements Serializable {
+
+    private static final long serialVersionUID = -5083451790123224811L;
+    protected final Taint tag;
+
+    private SerializationWrapper(Taint tag) {
+        this.tag = tag;
+    }
+
+    public abstract Object unwrap();
+
+    public static SerializationWrapper wrap(Boolean val) {
+        return new BooleanWrapper(val);
+    }
+
+    public static SerializationWrapper wrap(Byte val) {
+        return new ByteWrapper(val);
+    }
+
+    public static SerializationWrapper wrap(Character val) {
+        return new CharacterWrapper(val);
+    }
+
+    public static SerializationWrapper wrap(Short val) {
+        return new ShortWrapper(val);
+    }
+
+    private static class BooleanWrapper extends SerializationWrapper {
+
+        private static final long serialVersionUID = 391181930404648158L;
+        private final boolean val;
+
+        BooleanWrapper(Boolean val) {
+            super(MultiTainter.getTaint(val));
+            this.val = val;
+        }
+
+        @Override
+        public Object unwrap() {
+            return BoxedPrimitiveStoreWithObjTags.valueOf(tag, val);
+        }
+    }
+
+    private static class ByteWrapper extends SerializationWrapper {
+
+        private static final long serialVersionUID = 8430253026877283689L;
+        private final byte val;
+
+        ByteWrapper(Byte val) {
+            super(MultiTainter.getTaint(val));
+            this.val = val;
+        }
+
+        @Override
+        public Object unwrap() {
+            return BoxedPrimitiveStoreWithObjTags.valueOf(tag, val);
+        }
+    }
+
+    private static class CharacterWrapper extends SerializationWrapper {
+
+        private static final long serialVersionUID = 2766884087956504194L;
+        private final char val;
+
+        CharacterWrapper(Character val) {
+            super(MultiTainter.getTaint(val));
+            this.val = val;
+        }
+
+        @Override
+        public Object unwrap() {
+            return BoxedPrimitiveStoreWithObjTags.valueOf(tag, val);
+        }
+    }
+
+    private static class ShortWrapper extends SerializationWrapper {
+
+        private static final long serialVersionUID = -2702102915716255295L;
+        private final short val;
+
+        ShortWrapper(Short val) {
+            super(MultiTainter.getTaint(val));
+            this.val = val;
+        }
+
+        @Override
+        public Object unwrap() {
+            return BoxedPrimitiveStoreWithObjTags.valueOf(tag, val);
+        }
+    }
+}

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/WeakIdentityHashMap.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/WeakIdentityHashMap.java
@@ -1,0 +1,106 @@
+package edu.columbia.cs.psl.phosphor.struct;
+
+import java.io.Serializable;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.*;
+
+public class WeakIdentityHashMap<K, V> implements Serializable {
+
+    private final ReferenceQueue<Object> queue = new ReferenceQueue<>();
+    private final Map<IdentityWeakReference<K>, V> map;
+
+    public WeakIdentityHashMap() {
+        this.map = new HashMap<>();
+    }
+
+    public int size() {
+        expungeStaleEntries();
+        return map.size();
+    }
+
+    public boolean isEmpty() {
+        expungeStaleEntries();
+        return map.isEmpty();
+    }
+
+    public boolean containsKey(Object key) {
+        expungeStaleEntries();
+        return map.containsKey(new IdentityWeakReference<>(key, queue));
+    }
+
+    public boolean containsValue(Object value) {
+        expungeStaleEntries();
+        return map.containsValue(value);
+    }
+
+    public V get(Object key) {
+        expungeStaleEntries();
+        return map.get(new IdentityWeakReference<>(key, queue));
+    }
+
+    public V put(K key, V value) {
+        if(key == null) {
+            throw new IllegalArgumentException("WeakIdentityHashMap cannot have null keys");
+        }
+        expungeStaleEntries();
+        return map.put(new IdentityWeakReference<>(key, queue), value);
+    }
+
+    public V remove(Object key) {
+        expungeStaleEntries();
+        return map.remove(new IdentityWeakReference<>(key, queue));
+    }
+
+    public void clear() {
+        expungeStaleEntries();
+        map.clear();
+    }
+
+    public Set<K> keySet() {
+        expungeStaleEntries();
+        Set<K> ret = new HashSet<>();
+        for(IdentityWeakReference<K> ref : map.keySet()) {
+            K value = ref.get();
+            if(value != null) {
+                ret.add(value);
+            }
+        }
+        return Collections.unmodifiableSet(ret);
+    }
+
+    public Collection<V> values() {
+        expungeStaleEntries();
+        return map.values();
+    }
+
+    private void expungeStaleEntries() {
+        for(Reference ref; (ref = queue.poll()) != null; ) {
+            map.remove(ref);
+        }
+    }
+
+    private static class IdentityWeakReference<T> extends WeakReference<T> {
+
+        private final int hashCode;
+
+        IdentityWeakReference(T referent, ReferenceQueue<? super T> queue) {
+            super(referent, queue);
+            hashCode = System.identityHashCode(referent);
+        }
+
+        public int hashCode() {
+            return hashCode;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            WeakReference that = (WeakReference) o;
+            T referent = this.get();
+            return referent != null && referent == that.get();
+        }
+    }
+}

--- a/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/multid/MultiDTaintedArray.java
+++ b/Phosphor/src/edu/columbia/cs/psl/phosphor/struct/multid/MultiDTaintedArray.java
@@ -1,6 +1,7 @@
 package edu.columbia.cs.psl.phosphor.struct.multid;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 
 import org.objectweb.asm.Type;
 
@@ -145,6 +146,14 @@ public abstract class MultiDTaintedArray {
 			return MultiDTaintedArrayWithIntTag.getPrimitiveTypeForWrapper(internalName);
 		else
 			return MultiDTaintedArrayWithObjTag.getPrimitiveTypeForWrapper(internalName);
+	}
 
+	@SuppressWarnings("unused")
+	public static Object unboxMethodReceiverIfNecessary(Method m, Object obj) {
+		if(LazyArrayObjTags.class.isAssignableFrom(m.getDeclaringClass()) || LazyArrayIntTags.class.isAssignableFrom(m.getDeclaringClass())) {
+			return obj; // No unboxing is necessary
+		} else {
+			return unboxRaw(obj);
+		}
 	}
 }

--- a/Phosphor/test/edu/columbia/cs/psl/phosphor/util/IgnoredTestUtil.java
+++ b/Phosphor/test/edu/columbia/cs/psl/phosphor/util/IgnoredTestUtil.java
@@ -19,7 +19,7 @@ public class IgnoredTestUtil {
         TaintSourceWrapper.setStringValueTag(str, new LazyCharArrayObjTags(str.toCharArray(), tags));
     }
 
-    /* Replaces the taint tag for each character of the specified with a taint tag containing only the specified label. */
+    @SuppressWarnings("unused")
     public static void setStringCharTaints$$PHOSPHORTAGGED(String str, Object label, ControlTaintTagStack ctrl) {
         setStringCharTaints(str, label);
     }

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/GetSetTaintObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/GetSetTaintObjTagITCase.java
@@ -1,5 +1,6 @@
 package edu.columbia.cs.psl.test.phosphor;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
@@ -11,19 +12,19 @@ import edu.columbia.cs.psl.phosphor.runtime.Taint;
 import edu.columbia.cs.psl.phosphor.struct.TaintedWithObjTag;
 
 public class GetSetTaintObjTagITCase extends BaseMultiTaintClass{
-	
+
 	@Test
 	public void testReferenceType() throws Exception {
 		String s = "def";
 		HashMap<Object, Object> m =  new HashMap<Object, Object>();
 		MultiTainter.taintedObject(s, new Taint<>("a"));;
 		MultiTainter.taintedObject(m, new Taint<>("a"));
-		
+
 		int[] x = new int[10];
 		//In its default mode, Phosphor tracks ONLY for the array ELEMENTS - not for the reference
 		//can do -withArrayLengthTags to track a tag for the length of the array
 		x = MultiTainter.taintedIntArray(x, "b");
-		
+
 		assertTrue(((TaintedWithObjTag)m).getPHOSPHOR_TAG() != null);
 		assertTrue(MultiTainter.getTaint(m) != null);
 		assertTrue(MultiTainter.getTaint(s) != null);
@@ -40,7 +41,7 @@ public class GetSetTaintObjTagITCase extends BaseMultiTaintClass{
 		Long l = MultiTainter.taintedLong((long) 5, "a");
 		Float f = MultiTainter.taintedFloat(4f, "a");
 		Double d = MultiTainter.taintedDouble(4d, "a");
-		
+
 
 		assertTrue(MultiTainter.getTaint(z.booleanValue()) != null);
 		assertTrue(MultiTainter.getTaint(b.byteValue()) != null);
@@ -70,7 +71,7 @@ public class GetSetTaintObjTagITCase extends BaseMultiTaintClass{
 		long l = MultiTainter.taintedLong((long) 5, "a");
 		float f = MultiTainter.taintedFloat(4f, "a");
 		double d = MultiTainter.taintedDouble(4d, "a");
-		
+
 
 		assertTrue(MultiTainter.getTaint(z) != null);
 		assertTrue(MultiTainter.getTaint(b) != null);
@@ -81,7 +82,7 @@ public class GetSetTaintObjTagITCase extends BaseMultiTaintClass{
 		assertTrue(MultiTainter.getTaint(f) != null);
 		assertTrue(MultiTainter.getTaint(d) != null);
 	}
-	
+
 	@Test
 	public void testToString()
 	{
@@ -101,8 +102,8 @@ public class GetSetTaintObjTagITCase extends BaseMultiTaintClass{
 		assertNonNullTaint(Float.toString(f));
 		assertNonNullTaint(Double.toString(d));
 		assertNonNullTaint(Integer.toString(i));
-	}	
-	
+	}
+
 	@Test
 	public void testValueOf()
 	{
@@ -157,8 +158,34 @@ public class GetSetTaintObjTagITCase extends BaseMultiTaintClass{
 		assertTaintHasOnlyLabel(MultiTainter.getTaint(l6), lbl);
 		assertTaintHasOnlyLabel(MultiTainter.getTaint(f), lbl);
 		assertTaintHasOnlyLabel(MultiTainter.getTaint(f2), lbl);
-		assertTaintHasOnlyLabel(MultiTainter.getTaint(d), lbl);		
+		assertTaintHasOnlyLabel(MultiTainter.getTaint(d), lbl);
 		assertTaintHasOnlyLabel(MultiTainter.getTaint(d2), lbl);
 	}
 
+	@Test
+	public void testBoxedCharacterSameValue() {
+		int len = 10;
+		Character[] taintedChars1 = new Character[len];
+		for(int i = 0; i < taintedChars1.length; i++) {
+			taintedChars1[i] = MultiTainter.taintedChar('a', i);
+		}
+		Character[] nonTaintedChars = new Character[len];
+		for(int i = 0; i < nonTaintedChars.length; i++) {
+			nonTaintedChars[i] = 'a';
+		}
+		Character[] taintedChars2 = new Character[len];
+		for(int i = 0; i < taintedChars2.length; i++) {
+			taintedChars2[i] = MultiTainter.taintedChar('a', i);
+		}
+		for(int i = 0; i < len; i++) {
+			Taint t1 = MultiTainter.getTaint(taintedChars1[i]);
+			Taint t2 = MultiTainter.getTaint(taintedChars2[i]);
+			Taint t = MultiTainter.getTaint(nonTaintedChars[i]);
+			assertNonNullTaint(t1);
+			assertNonNullTaint(t2);
+			assertNullOrEmpty(t);
+			assertArrayEquals(new Object[]{i}, MultiTainter.getTaint(taintedChars1[i]).getLabels());
+			assertArrayEquals(new Object[]{i}, MultiTainter.getTaint(taintedChars2[i]).getLabels());
+		}
+	}
 }

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/GetSetTaintObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/GetSetTaintObjTagITCase.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 
+import edu.columbia.cs.psl.phosphor.runtime.BoxedPrimitiveStoreWithObjTags;
 import org.junit.Test;
 
 import edu.columbia.cs.psl.phosphor.runtime.MultiTainter;
@@ -30,9 +31,9 @@ public class GetSetTaintObjTagITCase extends BaseMultiTaintClass{
 		assertTrue(MultiTainter.getTaint(s) != null);
 		assertTrue(MultiTainter.getTaint(x[0]) != null);
 	}
+
 	@Test
-	public void testBoxing()
-	{
+	public void testBoxing() {
 		Boolean z = MultiTainter.taintedBoolean(false, "a");
 		Byte b = MultiTainter.taintedByte((byte) 4,"a");
 		Character c = MultiTainter.taintedChar('a', "a");
@@ -54,15 +55,13 @@ public class GetSetTaintObjTagITCase extends BaseMultiTaintClass{
 	}
 
 	@Test
-	public void testIntConstructorTaintsIntObject()
-	{
+	public void testIntConstructorTaintsIntObject() {
 		Integer i = new Integer(MultiTainter.taintedInt(5, "a"));
 		assertTrue(MultiTainter.getTaint(i)!=null);
-
 	}
+
 	@Test
-	public void testNotBoxing()
-	{
+	public void testNotBoxing() {
 		boolean z = MultiTainter.taintedBoolean(false, "a");
 		byte b = MultiTainter.taintedByte((byte) 4, "a");
 		char c = MultiTainter.taintedChar('a', "a");
@@ -84,8 +83,7 @@ public class GetSetTaintObjTagITCase extends BaseMultiTaintClass{
 	}
 
 	@Test
-	public void testToString()
-	{
+	public void testToString() {
 		boolean z = MultiTainter.taintedBoolean(false, "a");
 		byte b = MultiTainter.taintedByte((byte) 4, "a");
 		char c = MultiTainter.taintedChar('a', "a");
@@ -105,8 +103,7 @@ public class GetSetTaintObjTagITCase extends BaseMultiTaintClass{
 	}
 
 	@Test
-	public void testValueOf()
-	{
+	public void testValueOf() {
 		String hundred = new String(new char[]{'1','0','0'});
 		Integer lbl = 5;
 		String TRUE = new String(new char[]{'t','r','u','e'});
@@ -163,29 +160,70 @@ public class GetSetTaintObjTagITCase extends BaseMultiTaintClass{
 	}
 
 	@Test
-	public void testBoxedCharacterSameValue() {
+	public void testBoxedBooleanSameValueDifferentTags() {
 		int len = 10;
-		Character[] taintedChars1 = new Character[len];
-		for(int i = 0; i < taintedChars1.length; i++) {
-			taintedChars1[i] = MultiTainter.taintedChar('a', i);
-		}
-		Character[] nonTaintedChars = new Character[len];
-		for(int i = 0; i < nonTaintedChars.length; i++) {
-			nonTaintedChars[i] = 'a';
-		}
-		Character[] taintedChars2 = new Character[len];
-		for(int i = 0; i < taintedChars2.length; i++) {
-			taintedChars2[i] = MultiTainter.taintedChar('a', i);
+		Boolean[] taintedValues = new Boolean[len];
+		Boolean[] nonTaintedValues = new Boolean[len];
+		for(int i = 0; i < len; i++) {
+			taintedValues[i] = MultiTainter.taintedBoolean(true, i);
+			nonTaintedValues[i] = true;
 		}
 		for(int i = 0; i < len; i++) {
-			Taint t1 = MultiTainter.getTaint(taintedChars1[i]);
-			Taint t2 = MultiTainter.getTaint(taintedChars2[i]);
-			Taint t = MultiTainter.getTaint(nonTaintedChars[i]);
-			assertNonNullTaint(t1);
-			assertNonNullTaint(t2);
-			assertNullOrEmpty(t);
-			assertArrayEquals(new Object[]{i}, MultiTainter.getTaint(taintedChars1[i]).getLabels());
-			assertArrayEquals(new Object[]{i}, MultiTainter.getTaint(taintedChars2[i]).getLabels());
+			assertNullOrEmpty(MultiTainter.getTaint(nonTaintedValues[i]));
+			Taint tag = MultiTainter.getTaint(taintedValues[i]);
+			assertNonNullTaint(tag);
+			assertArrayEquals(new Object[]{i}, tag.getLabels());
+		}
+	}
+
+	@Test
+	public void testBoxedByteSameValueDifferentTags() {
+		int len = 10;
+		Byte[] taintedValues = new Byte[len];
+		Byte[] nonTaintedValues = new Byte[len];
+		for(int i = 0; i < len; i++) {
+			taintedValues[i] = MultiTainter.taintedByte((byte)5, i);
+			nonTaintedValues[i] = 5;
+		}
+		for(int i = 0; i < len; i++) {
+			assertNullOrEmpty(MultiTainter.getTaint(nonTaintedValues[i]));
+			Taint tag = MultiTainter.getTaint(taintedValues[i]);
+			assertNonNullTaint(tag);
+			assertArrayEquals(new Object[]{i}, tag.getLabels());
+		}
+	}
+	
+	@Test
+	public void testBoxedCharSameValueDifferentTags() {
+		int len = 10;
+		Character[] taintedValues = new Character[len];
+		Character[] nonTaintedValues = new Character[len];
+		for(int i = 0; i < len; i++) {
+			taintedValues[i] = MultiTainter.taintedChar('a', i);
+			nonTaintedValues[i] = 'a';
+		}
+		for(int i = 0; i < len; i++) {
+			assertNullOrEmpty(MultiTainter.getTaint(nonTaintedValues[i]));
+			Taint tag = MultiTainter.getTaint(taintedValues[i]);
+			assertNonNullTaint(tag);
+			assertArrayEquals(new Object[]{i}, tag.getLabels());
+		}
+	}
+
+	@Test
+	public void testBoxedShortSameValueDifferentTags() {
+		int len = 10;
+		Short[] taintedValues = new Short[len];
+		Short[] nonTaintedValues = new Short[len];
+		for(int i = 0; i < len; i++) {
+			taintedValues[i] = MultiTainter.taintedShort((short)7, i);
+			nonTaintedValues[i] = 7;
+		}
+		for(int i = 0; i < len; i++) {
+			assertNullOrEmpty(MultiTainter.getTaint(nonTaintedValues[i]));
+			Taint tag = MultiTainter.getTaint(taintedValues[i]);
+			assertNonNullTaint(tag);
+			assertArrayEquals(new Object[]{i}, tag.getLabels());
 		}
 	}
 }

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/runtime/SerializationImplicitITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/runtime/SerializationImplicitITCase.java
@@ -1,0 +1,4 @@
+package edu.columbia.cs.psl.test.phosphor.runtime;
+
+public class SerializationImplicitITCase extends SerializationObjTagITCase {
+}

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/runtime/SerializationObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/runtime/SerializationObjTagITCase.java
@@ -2,7 +2,6 @@ package edu.columbia.cs.psl.test.phosphor.runtime;
 
 import edu.columbia.cs.psl.phosphor.runtime.MultiTainter;
 import edu.columbia.cs.psl.phosphor.runtime.Taint;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -271,7 +270,6 @@ public class SerializationObjTagITCase extends FieldHolderBaseTest {
     }
 
     /* Checks that when tainted primitives are serialized and then deserialized the deserialized primitives are tainted. */
-    @Ignore
     @Test
     public void testSerializeTaintedPrimitives() throws Exception {
         checkSerializePrimitives(true);

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/runtime/SerializationObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/runtime/SerializationObjTagITCase.java
@@ -2,7 +2,8 @@ package edu.columbia.cs.psl.test.phosphor.runtime;
 
 import edu.columbia.cs.psl.phosphor.runtime.MultiTainter;
 import edu.columbia.cs.psl.phosphor.runtime.Taint;
-import edu.columbia.cs.psl.phosphor.util.IgnoredTestUtil;
+import edu.columbia.cs.psl.phosphor.struct.PowerSetTree;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -17,6 +18,11 @@ public class SerializationObjTagITCase extends FieldHolderBaseTest {
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
+
+    @After
+    public void reset() {
+        PowerSetTree.getInstance().reset();
+    }
 
     public static class PrimitiveArrayHolderChild extends PrimitiveArrayHolder {
 

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/runtime/SerializationObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/runtime/SerializationObjTagITCase.java
@@ -2,6 +2,7 @@ package edu.columbia.cs.psl.test.phosphor.runtime;
 
 import edu.columbia.cs.psl.phosphor.runtime.MultiTainter;
 import edu.columbia.cs.psl.phosphor.runtime.Taint;
+import edu.columbia.cs.psl.phosphor.util.IgnoredTestUtil;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;

--- a/Phosphor/test/edu/columbia/cs/psl/test/phosphor/runtime/SerializationObjTagITCase.java
+++ b/Phosphor/test/edu/columbia/cs/psl/test/phosphor/runtime/SerializationObjTagITCase.java
@@ -2,14 +2,12 @@ package edu.columbia.cs.psl.test.phosphor.runtime;
 
 import edu.columbia.cs.psl.phosphor.runtime.MultiTainter;
 import edu.columbia.cs.psl.phosphor.runtime.Taint;
-import edu.columbia.cs.psl.test.phosphor.BaseMultiTaintClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.*;
-import java.lang.reflect.Array;
 import java.math.BigInteger;
 
 import static org.junit.Assert.*;


### PR DESCRIPTION
* Fixed issues with keeping taint tag when serializing primitives and boxed primitives (fixes #123)
* "Added" tests for serialization with implicit tracking enabled
* Fixed issue with serialization with implicit tracking where Phosphor tries to incorrectly unwrap primitive array wrapper before call to native method NativeMethodAccessorImpl.invoke0 but method being invoked is the writeObject or readObject method for the primitive wrapper type
* Changed BoxedPrimitiveStoreWithObjTags to use a WeakIdentityHashMap to prevent store tags for Bytes/Booleans/Characters/Shorts with the same value from being overwritten
* Added tests that reveal prior issue with BoxedPrimitiveStoreWithObjTags overwriting tags for Bytes/Booleans/Characters/Shorts with the same value 