### PR TITLE
#150 add sanity check to avoid addTypeParams to tainted methods

### DIFF
--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/runtime/ReflectionMasker.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/runtime/ReflectionMasker.java
@@ -295,6 +295,9 @@ public class ReflectionMasker {
         newParams.add(Configuration.TAINT_TAG_OBJ_CLASS);
         LinkedList<Class<?>> wrapped = new LinkedList<>();
         for(Class<?> c : (Class[]) params.val) {
+            if (c.equals(Taint.class)) {
+                return params;
+            }
             Type t = Type.getType(c);
             if(t.getSort() == Type.ARRAY) {
                 newParams.add(MultiDTaintedArray.getUnderlyingBoxClassForUnderlyingClass(c));


### PR DESCRIPTION
This PR is to solve the #150 . If current method is tainted method, we just return the original parameter list when `addTypeParams`.