### PR TITLE
Fix object leaking through argWrapper

### DIFF
--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/TaintAdapter.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/TaintAdapter.java
@@ -707,14 +707,14 @@ public class TaintAdapter extends MethodVisitor implements Opcodes {
             Type t = getTopOfStackType();
             ts[i] = t;
             tmp[i] = lvs.getTmpLV(t);
-            if (forceUnwrapObjects && expected.getDescriptor().equals("Ljava/lang/Object;") && !topOfStackIsNull()) {
+            if (forceUnwrapObjects && expected.getDescriptor().equals("Ljava/lang/Object;")) {
                 super.visitInsn(DUP);
                 pushPhosphorStackFrame();
                 super.visitInsn(SWAP);
                 push(idxOfThisArg);
                 SET_ARG_WRAPPER.delegateVisit(mv);
                 ENSURE_UNBOXED.delegateVisit(mv);
-            } else if (TaintUtils.isWrappedType(expected) && !topOfStackIsNull() && t.getSort() != Type.ARRAY) {
+            } else if (TaintUtils.isWrappedType(expected) && t.getSort() != Type.ARRAY) {
                 super.visitInsn(DUP);
                 pushPhosphorStackFrame();
                 super.visitInsn(SWAP);

--- a/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/ArrayArgWrapperObjTagITCase.java
+++ b/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/ArrayArgWrapperObjTagITCase.java
@@ -1,0 +1,21 @@
+package edu.columbia.cs.psl.test.phosphor;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertNull;
+
+public class ArrayArgWrapperObjTagITCase {
+
+    @Test
+    public void testArgWrapperTaintNotLeaked() {
+        byte[] b = new byte[]{1, 2, 3};
+        Arrays.copyOf(b, 3); // `copyof` calls System.arraycopy which is not instrumented.
+        checkNull(null);
+    }
+
+    public void checkNull(byte[] input) {
+        assertNull(input);
+    }
+}

--- a/phosphor-instrument-jigsaw/pom.xml
+++ b/phosphor-instrument-jigsaw/pom.xml
@@ -98,6 +98,7 @@
             <plugin>
                 <groupId>org.moditect</groupId>
                 <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.RC2</version>
                 <executions>
                     <execution>
                         <id>add-module-info</id>


### PR DESCRIPTION
This PR fixes the object leaking when a non-instrumented method is called. It basically removes the optimization that does not update `argWrapper` when the top of the stack is null. Another solution is to check if the callee is instrumented. I'm not sure about the performance impact of this optimization. If it is negligible I feel this solution is better than adding additional checks to the callee. 

A new test case is attached. 

The pom.xml update helps me to build phosphor on Ubuntu. I'm happy to revert this change if it breaks your build. 

Test: `mvn verify`

