### PR TITLE
Fix object leaking through argWrapper 

### DIFF
--- a/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/ArrayArgWrapperObjTagITCase.java
+++ b/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/ArrayArgWrapperObjTagITCase.java
@@ -1,0 +1,26 @@
+package edu.columbia.cs.psl.test.phosphor;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertNull;
+
+public class ArrayArgWrapperObjTagITCase {
+
+    @Test
+    public void testArgWrapperTaintNotLeaked() {
+        byte[] b = new byte[]{1, 2, 3};
+        Arrays.copyOf(b, 3); // `copyof` calls System.arraycopy which is not instrumented.
+        checkNull(null);
+    }
+
+    @Test
+    public void testNoUnwrapForNull() {
+        checkNull(null);
+    }
+    
+    public void checkNull(byte[] input) {
+        assertNull(input);
+    }
+}


### PR DESCRIPTION
This PR fixes the object leaking when a non-instrumented method is called. It basically removes the optimization that does not update argWrapper when the top of the stack is null. Another solution is to check if the callee is instrumented. I'm not sure about the performance impact of this optimization. If it is negligible I feel this solution is better than adding additional checks to the callee.

A new test case is attached.

The `pom.xml` update helps me to build phosphor on Ubuntu and the `StandaloneJVMInstrumenter` update fixes an NPE. I'm happy to revert this change if it breaks your build.

Test: mvn verify
