### PR TITLE
Fix stack frame verification exception when taint is diabled.

### DIFF
--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/InstOrUninstChoosingMV.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/InstOrUninstChoosingMV.java
@@ -13,6 +13,7 @@ public class InstOrUninstChoosingMV extends MethodVisitor {
     }
 
     public void disableTainting() {
+        umv.lvs.disable();
         this.mv = umv;
     }
 }

--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/UninstrumentedCompatMV.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/UninstrumentedCompatMV.java
@@ -141,11 +141,6 @@ public class UninstrumentedCompatMV extends TaintAdapter {
                         super.visitFieldInsn(opcode, owner, name, desc);
                     } else {
                         //It's not wrapped
-                        if (opcode == Opcodes.PUTFIELD) {
-                            super.visitInsn(DUP2);
-                        } else {
-                            super.visitInsn(DUP);
-                        }
                         super.visitFieldInsn(opcode, owner, name, desc);
                         String factoryType = desc;
                         if (t.getElementType().getSort() == Type.OBJECT) {

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -12,11 +12,13 @@
     <properties>
         <dacapo.skip>true</dacapo.skip>
         <skipDataFlowTests>false</skipDataFlowTests>
+        <skipInstrumentationTest>false</skipInstrumentationTest>
         <skipControlFlowTests>false</skipControlFlowTests>
         <auto.taint>
             taintSources=${basedir}/src/test/resources/taint-sources,taintSinks=${basedir}/src/test/resources/taint-sinks,taintThrough=${basedir}/src/test/resources/taint-through
         </auto.taint>
         <data.flow.cache>${project.build.directory}/cached-data-flows</data.flow.cache>
+        <instrumentation.cache>${project.build.directory}/cached-instrumentations</instrumentation.cache>
         <control.flow.cache>${project.build.directory}/cached-control-flows</control.flow.cache>
         <data.flow.jvm>jvm-inst-data</data.flow.jvm>
         <control.flow.jvm>jvm-inst-control</control.flow.jvm>
@@ -245,6 +247,24 @@
                                     <reuseForks>false</reuseForks>
                                     <argLine>
                                         ${argLine.prefix},enum,acmpeq,cacheDir=${data.flow.cache}
+                                    </argLine>
+                                </configuration>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>integration-test-instrumentation</id>
+                                <configuration>
+                                    <skipTests>${skipInstrumentationTest}</skipTests>
+                                    <jvm>${project.build.directory}/${data.flow.jvm}/bin/java</jvm>
+                                    <includes>
+                                        <include>**/*InstCase.java</include>
+                                    </includes>
+                                    <reuseForks>false</reuseForks>
+                                    <argLine>
+                                        ${argLine.prefix},enum,acmpeq,cacheDir=${instrumentation.cache}
                                     </argLine>
                                 </configuration>
                                 <goals>

--- a/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/ClassWithLargeMethod.java
+++ b/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/ClassWithLargeMethod.java
@@ -1,0 +1,3102 @@
+package edu.columbia.cs.psl.test.phosphor;
+
+
+import java.util.*;
+
+// This class has a large static init `<clinit>` method
+// that will force instrumentation fail.
+public enum ClassWithLargeMethod {
+    Foo0(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo1(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo2(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo3(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo4(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo5(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo6(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo7(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo8(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo9(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo10(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo11(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo12(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo13(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo14(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo15(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo16(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo17(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo18(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo19(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo20(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo21(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo22(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo23(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo24(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo25(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo26(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo27(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo28(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo29(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo30(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo31(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo32(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo33(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo34(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo35(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo36(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo37(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo38(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo39(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo40(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo41(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo42(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo43(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo44(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo45(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo46(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo47(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo48(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo49(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo50(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo51(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo52(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo53(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo54(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo55(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo56(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo57(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo58(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo59(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo60(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo61(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo62(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo63(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo64(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo65(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo66(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo67(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo68(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo69(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo70(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo71(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo72(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo73(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo74(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo75(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo76(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo77(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo78(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo79(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo80(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo81(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo82(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo83(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo84(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo85(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo86(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo87(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo88(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo89(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo90(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo91(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo92(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo93(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo94(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo95(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo96(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo97(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo98(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo99(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo100(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo101(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo102(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo103(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo104(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo105(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo106(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo107(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo108(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo109(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo110(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo111(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo112(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo113(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo114(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo115(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo116(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo117(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo118(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo119(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo120(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo121(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo122(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo123(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo124(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo125(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo126(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo127(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo128(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo129(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo130(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo131(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo132(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo133(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo134(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo135(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo136(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo137(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo138(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo139(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo140(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo141(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo142(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo143(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo144(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo145(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo146(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo147(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo148(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo149(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo150(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo151(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo152(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo153(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo154(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo155(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo156(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo157(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo158(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo159(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo160(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo161(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo162(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo163(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo164(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo165(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo166(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo167(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo168(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo169(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo170(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo171(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo172(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo173(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo174(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo175(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo176(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo177(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo178(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo179(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo180(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo181(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo182(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo183(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo184(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo185(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo186(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo187(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo188(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo189(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo190(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo191(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo192(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo193(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo194(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo195(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo196(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo197(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo198(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo199(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo200(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo201(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo202(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo203(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo204(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo205(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo206(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo207(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo208(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo209(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo210(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo211(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo212(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo213(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo214(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo215(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo216(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo217(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo218(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo219(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo220(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo221(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo222(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo223(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo224(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo225(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo226(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo227(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo228(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo229(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo230(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo231(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo232(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo233(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo234(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo235(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo236(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo237(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo238(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo239(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo240(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo241(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo242(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo243(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo244(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo245(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo246(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo247(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo248(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo249(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo250(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo251(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo252(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo253(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo254(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo255(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo256(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo257(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo258(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo259(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo260(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo261(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo262(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo263(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo264(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo265(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo266(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo267(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo268(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo269(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo270(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo271(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo272(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo273(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo274(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo275(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo276(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo277(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo278(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo279(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo280(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo281(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo282(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo283(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo284(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo285(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo286(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo287(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo288(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo289(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo290(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo291(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo292(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo293(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo294(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo295(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo296(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo297(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo298(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    ),
+    Foo299(
+            0x0001,
+            "NULL-MD5",
+            false,
+            false,
+            0,
+            0,
+            new String[] {"SSL_RSA_WITH_NULL_MD5"},
+            null
+    );
+
+
+
+    private final int id;
+    private final String openSSLAlias;
+    private final Set<String> openSSLAltNames;
+    private final Set<String> jsseNames;
+    private final boolean export;
+    private final boolean fipsCompatible;
+    /**
+     * Number of bits really used
+     */
+    private final int strength_bits;
+    /**
+     * Number of bits for algorithm
+     */
+    private final int alg_bits;
+
+    private ClassWithLargeMethod(int id, String openSSLAlias,
+                                 boolean export,
+                                 boolean fipsCompatible, int strength_bits, int alg_bits, String[] jsseAltNames,
+                                 String[] openSSlAltNames) {
+        this.id = id;
+        this.openSSLAlias = openSSLAlias;
+        if (openSSlAltNames != null && openSSlAltNames.length != 0) {
+            Set<String> altNames = new HashSet<>(Arrays.asList(openSSlAltNames));
+            this.openSSLAltNames = Collections.unmodifiableSet(altNames);
+        } else {
+            this.openSSLAltNames = Collections.emptySet();
+        }
+        Set<String> jsseNames = new LinkedHashSet<>();
+        if (jsseAltNames != null && jsseAltNames.length != 0) {
+            jsseNames.addAll(Arrays.asList(jsseAltNames));
+        }
+        jsseNames.add(name());
+        this.jsseNames = Collections.unmodifiableSet(jsseNames);
+        this.export = export;
+        this.fipsCompatible = fipsCompatible;
+        this.strength_bits = strength_bits;
+        this.alg_bits = alg_bits;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getOpenSSLAlias() {
+        return openSSLAlias;
+    }
+
+    public Set<String> getOpenSSLAltNames() {
+        return openSSLAltNames;
+    }
+
+    public Set<String> getJsseNames() {
+        return jsseNames;
+    }
+
+
+    public boolean isExport() {
+        return export;
+    }
+
+
+    public boolean isFipsCompatible() {
+        return fipsCompatible;
+    }
+
+    public int getStrength_bits() {
+        return strength_bits;
+    }
+
+    public int getAlg_bits() {
+        return alg_bits;
+    }
+
+
+    private static final Map<Integer, ClassWithLargeMethod> idMap = new HashMap<>();
+
+    static {
+        for (ClassWithLargeMethod cipher : ClassWithLargeMethod.values()) {
+            int id = cipher.getId();
+
+            if (id > 0 && id < 0xFFFF) {
+                idMap.put(Integer.valueOf(id), cipher);
+            }
+        }
+    }
+
+
+    public static ClassWithLargeMethod valueOf(int cipherId) {
+        return idMap.get(Integer.valueOf(cipherId));
+    }
+}

--- a/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/LocalVariableInstCase.java
+++ b/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/LocalVariableInstCase.java
@@ -1,0 +1,13 @@
+package edu.columbia.cs.psl.test.phosphor;
+
+import org.junit.Test;
+
+public class LocalVariableInstCase {
+    @Test
+    public void testLocalVariableVerifySuccessWhenTaintDisabled() {
+        // We only need to load this class to trigger JVM verification.
+        for (ClassWithLargeMethod value : ClassWithLargeMethod.values()) {
+            // NOOP
+        }
+    }
+}


### PR DESCRIPTION
There are two issues while using `UninstrumentedCompatMV`

1. The LocalVariableManager should be disabled (do not try to allocate new local variables). 
2. While visiting `PUTSTATIC` instruction, do not add two `DUP` instructions. 

A new test case is attached. Sorry for submitting a huge file `ClassWithLargeMethod.java` I can't trigger this code path with a simple class implementation. Note that the content of the class does not matter. 