### PR TITLE
Fix off by 1 error in codePointBefore

### DIFF
--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/runtime/CharacterUtils.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/runtime/CharacterUtils.java
@@ -122,12 +122,13 @@ public class CharacterUtils {
 
     public static int codePointBefore(char[] tags, int i, PhosphorStackFrame phosphorStackFrame) {
         try {
+            int ret = Character.codePointBefore(tags, i);
+            i--;
             Taint retTaint = Taint.emptyTaint();
             TaggedCharArray wrapper = phosphorStackFrame.getArgWrapper(0, tags);
             if(wrapper.taints != null) {
                 retTaint = wrapper.taints[i];
             }
-            int ret = Character.codePointBefore(tags, i);
             phosphorStackFrame.setReturnTaint(retTaint);
             return ret;
         } catch(StringIndexOutOfBoundsException ex) {
@@ -141,6 +142,7 @@ public class CharacterUtils {
         Taint t = phosphorStackFrame.getArgTaint(1);
         try {
             int ret = Character.codePointBefore(seq, i);
+            i--;
             Taint retTaint = Taint.emptyTaint();
             if(Configuration.IS_JAVA_8){
                 if(seq instanceof String && InstrumentedJREFieldHelper.JAVA_8getvaluePHOSPHOR_WRAPPER((String) seq) != null && InstrumentedJREFieldHelper.JAVA_8getvaluePHOSPHOR_WRAPPER((String) seq).taints  != null) {
@@ -164,12 +166,13 @@ public class CharacterUtils {
     public static int codePointBefore(char[] tags, int i, int i2, PhosphorStackFrame phosphorStackFrame) {
         Taint t = phosphorStackFrame.getArgTaint(1);
         try {
+            int ret = Character.codePointBefore(tags, i, i2);
+            i--;
             Taint retTaint = Taint.emptyTaint();
             TaggedCharArray wrapper = phosphorStackFrame.getArgWrapper(0, tags);
             if(wrapper.taints != null) {
                 retTaint = wrapper.taints[i];
             }
-            int ret = Character.codePointBefore(tags, i, i2);
             phosphorStackFrame.setReturnTaint(retTaint);
             return ret;
         } catch(StringIndexOutOfBoundsException ex) {

--- a/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/CharacterCodePointObjTagITCase.java
+++ b/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/CharacterCodePointObjTagITCase.java
@@ -1,8 +1,11 @@
 package edu.columbia.cs.psl.test.phosphor;
 
 import edu.columbia.cs.psl.phosphor.runtime.MultiTainter;
+import edu.columbia.cs.psl.phosphor.util.IgnoredTestUtil;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class CharacterCodePointObjTagITCase extends BasePhosphorTest {
 	@Test
@@ -14,6 +17,18 @@ public class CharacterCodePointObjTagITCase extends BasePhosphorTest {
 
 		final char[] crar = Character.toChars(Character.codePointAt(c, 0));
 		Assert.assertNotNull(MultiTainter.getTaint(crar[0]));
+	}
 
+	@Test
+	public void testCodePointBefore() {
+		char[] s = {'a', 'b', 'c', 'd', 'e'};
+		for (int i = 0; i < 5; i++) {
+			s[i] = MultiTainter.taintedChar(s[i], i);
+		}
+
+		for (int i = 1; i <= 5; i++) {
+			int ret = Character.codePointBefore(s, i);
+			assertEquals(MultiTainter.getTaint(ret).getLabels()[0], i-1);
+		}
 	}
 }


### PR DESCRIPTION
According to the document: `codePointBefore` returns the char at index-1 (https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Character.html#codePointBefore(char%5B%5D,int)).

This PR fixes the issue and adds a new integration test. 