### PR TITLE
Fix missing unsafe wrapper.

### DIFF
--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/ReflectionHidingMV.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/ReflectionHidingMV.java
@@ -427,11 +427,15 @@ public class ReflectionHidingMV extends MethodVisitor implements Opcodes {
     }
 
     private boolean isUnsafeCopyMemory(String owner, String name, String nameWithoutSuffix) {
-        if (!Instrumenter.isUnsafeClass(owner)) {
-            return false;
-        } else {
-            return "copyMemory".equals(nameWithoutSuffix);
+        if (Instrumenter.isUnsafeClass(owner)) {
+            switch (nameWithoutSuffix) {
+                case "copyMemory":
+                case "copySwapMemory":
+                    return true;
+            }
+
         }
+        return false;
     }
 
     @Override

--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/runtime/RuntimeJDKInternalUnsafePropagator.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/runtime/RuntimeJDKInternalUnsafePropagator.java
@@ -208,6 +208,21 @@ public class RuntimeJDKInternalUnsafePropagator {
         unsafe.copyMemory(srcAddress, destAddress, length);
     }
 
+    public static void copySwapMemory(UnsafeProxy unsafe, Object srcBase, long srcOffset, Object destBase,
+                                      long destOffset, long bytes, long elemSize, PhosphorStackFrame stackFrame) {
+        if (srcBase instanceof TaggedArray) {
+            srcBase = ((TaggedArray) srcBase).getVal();
+        }
+        if (destBase instanceof TaggedArray) {
+            destBase = ((TaggedArray) destBase).getVal();
+        }
+        unsafe.copySwapMemory(srcBase, srcOffset, destBase, destOffset, bytes, elemSize);
+    }
+
+    public static void copySwapMemory(UnsafeProxy unsafe, long srcAddress, long destAddress, long bytes, long elemSize, PhosphorStackFrame stackFrame) {
+        unsafe.copySwapMemory(srcAddress, destAddress, bytes, elemSize);
+    }
+
     @SuppressWarnings("unused")
     public static Object allocateUninitializedArray(UnsafeProxy unsafe, Class c, int len, PhosphorStackFrame phosphorStackFrame) {
         Object ret = unsafe.allocateUninitializedArray(c, len);


### PR DESCRIPTION
This PR fixes the missing wrapper for unsafe method `copySwapMemory`. The implementation is similar to `copyMemory`. 

