### PR TITLE
Fix crashes when custom class visitors and tag factories are provided.

### DIFF
--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/SerializationFixingCV.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/SerializationFixingCV.java
@@ -36,6 +36,9 @@ public class SerializationFixingCV extends ClassVisitor implements Opcodes {
     @Override
     public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
         MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
+        if (Configuration.taintTagFactory.isIgnoredMethod(className, name, desc)) {
+            return mv;
+        }
         if (STREAM_CLASS_NAME.equals(className)) {
             return new StreamClassMV(mv);
         } else {
@@ -78,8 +81,8 @@ public class SerializationFixingCV extends ClassVisitor implements Opcodes {
      * specified name.
      */
     public static boolean isApplicable(String className) {
-        return INPUT_STREAM_NAME.equals(className) || OUTPUT_STREAM_NAME.equals(className)
-                || STREAM_CLASS_NAME.equals(className);
+        return (INPUT_STREAM_NAME.equals(className) || OUTPUT_STREAM_NAME.equals(className)
+                || STREAM_CLASS_NAME.equals(className)) && !Configuration.taintTagFactory.isIgnoredClass(className);
     }
 
     @SuppressWarnings("unused")

--- a/phosphor-instrument-jigsaw/src/main/java/module-info.java
+++ b/phosphor-instrument-jigsaw/src/main/java/module-info.java
@@ -1,5 +1,8 @@
 module edu.columbia.cs.psl.jigsaw.phosphor.instrumenter {
     exports edu.columbia.cs.psl.jigsaw.phosphor.instrumenter;
+    opens edu.columbia.cs.psl.phosphor.instrumenter;
+    opens edu.columbia.cs.psl.phosphor.struct.harmony.util;
+    opens edu.columbia.cs.psl.phosphor.org.objectweb.asm;
     requires jdk.jlink;
     requires java.instrument;
 }


### PR DESCRIPTION
This PR fixes two issues when custom class visitors or tag factories are provided. 

1.  Skip `SerializationFixingCV` if stream classes are ignored by `taintTagFactory`.
2. Fix classpath and module issues while using `jlink` with custom class visitors.