### PR TITLE
Fix NPE and compilation issues.

### DIFF
--- a/phosphor-instrument-jigsaw/pom.xml
+++ b/phosphor-instrument-jigsaw/pom.xml
@@ -98,6 +98,7 @@
             <plugin>
                 <groupId>org.moditect</groupId>
                 <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.RC2</version>
                 <executions>
                     <execution>
                         <id>add-module-info</id>

--- a/phosphor-instrument-jigsaw/src/main/java/edu/columbia/cs/psl/jigsaw/phosphor/instrumenter/StandaloneJVMInstrumenter.java
+++ b/phosphor-instrument-jigsaw/src/main/java/edu/columbia/cs/psl/jigsaw/phosphor/instrumenter/StandaloneJVMInstrumenter.java
@@ -24,7 +24,7 @@ public class StandaloneJVMInstrumenter {
     private static Properties toProperties(CommandLine line){
         Properties ret = new Properties();
         for(Option opt : line.getOptions()){
-            String name = opt.getArgName();
+            String name = opt.getOpt();
             String value = line.getOptionValue(name);
             if(value != null){
                 ret.setProperty(name, value);


### PR DESCRIPTION
- Fix missing dependency while building phosphor on Ubuntu
- Fix NPE while passing args to StandaloneJVMInstrumenter