### PR TITLE
Fix local variable table labels for added variables.

### DIFF
--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/LocalVariableManager.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/LocalVariableManager.java
@@ -280,17 +280,20 @@ public class LocalVariableManager extends OurLocalVariablesSorter implements Opc
         if (start == oldStartLabel) {
             start = this.newStartLabel;
         }
+        if (!Configuration.SKIP_LOCAL_VARIABLE_TABLE) {
+            if (varToShadowVar.containsKey(index)) {
+                int shadowVar = varToShadowVar.get(index);
+                if (curLocalIdxToLVNode.containsKey(shadowVar)) {
+                    LocalVariableNode n = curLocalIdxToLVNode.get(shadowVar);
+                    uninstMV.visitLocalVariable(n.name, n.desc, n.signature, start, end, n.index);
+                }
+            }
+        }
         super.visitLocalVariable(name, desc, signature, start, end, index);
         if (!createdLVs.isEmpty()) {
             if (!endVisited) {
                 super.visitLabel(this.end);
                 endVisited = true;
-            }
-            if (!Configuration.SKIP_LOCAL_VARIABLE_TABLE) {
-                for (LocalVariableNode n : createdLVs) {
-                    uninstMV.visitLocalVariable(n.name, n.desc, n.signature, n.start.getLabel(), n.end.getLabel(),
-                            n.index);
-                }
             }
             createdLVs.clear();
         }


### PR DESCRIPTION
I saw `com.sun.jdi.InconsistentDebugInfoException` exception when I attach the debugger to an instrumented application. The exception is caused by inconsistent scope information for shadow variables. This PR makes the shadow variable have the same scope information as the original local variable. 

I don't have a good integration test for this since the exception is thrown by my debugger. I use the following test case and verify the debugger works correctly after the fix. 

```java
import edu.columbia.cs.psl.phosphor.runtime.MultiTainter;

public class TestDebug {
    public static void print(String a, String b, String c, String d) {
        if (check()) {
            String s0 = MultiTainter.taintedReference(null, "123");
            System.out.println(MultiTainter.getTaint(s0));
        }

        if (check()) {
            String s1 = null;
            System.out.println(MultiTainter.getTaint(s1));
        }
    }

    public static void assertEquals(double expected, double actual, double delta) {
        System.out.println(expected + actual + delta);
    }

    private static boolean check() {
        return true;
    }

}
```