### PR TITLE
Terminate instrumentation when TaintInstrumented annotation is found.

### DIFF
--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/PreMain.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/PreMain.java
@@ -122,8 +122,8 @@ public class PreMain {
                     cn.version = 51;
                     upgradeVersion = true;
                 }
-                if (cn.visibleAnnotations != null) {
-                    for (Object o : cn.visibleAnnotations) {
+                if (cn.invisibleAnnotations != null) {
+                    for (Object o : cn.invisibleAnnotations) {
                         AnnotationNode an = (AnnotationNode) o;
                         if (an.desc.equals(Type.getDescriptor(TaintInstrumented.class))) {
                             return classfileBuffer;


### PR DESCRIPTION
The `TaintTrackingClassVisitor` adds an invisible annotation to the class file https://github.com/gmu-swe/phosphor/blob/9ac22f5252468e6fb619c1bc69624fa30fec19e5/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/TaintTrackingClassVisitor.java#L189. Therefore, we should check `invisibleAnnotations` instead of `visitbleAnnotations`.