### PR TITLE
Fixes Issue 188 - Crashes around MethodHandleImpl

### DIFF
--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/ReflectionHidingMV.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/ReflectionHidingMV.java
@@ -484,7 +484,7 @@ public class ReflectionHidingMV extends MethodVisitor implements Opcodes {
                 return;
             }
             /*
-             * Fix for #181 - if we are in a wrapped method, and called by the wrapper, we need to get the caller class
+             * Fix for #188 - if we are in a wrapped method, and called by the wrapper, we need to get the caller class
              * of the wrapper, not of this stack frame
              */
             if(owner.equals("jdk/internal/reflect/Reflection") && name.equals("getCallerClass")){

--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/TaintMethodRecord.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/TaintMethodRecord.java
@@ -73,6 +73,8 @@ public enum TaintMethodRecord implements MethodRecord {
     GET_RETURN_TAINT(INVOKEVIRTUAL, PhosphorStackFrame.class, "getReturnTaint", Taint.class, false),
     SET_RETURN_TAINT(INVOKEVIRTUAL, PhosphorStackFrame.class, "setReturnTaint", Void.TYPE, false, Taint.class),
     SET_ARG_WRAPPER(INVOKEVIRTUAL, PhosphorStackFrame.class, "setArgWrapper", Void.TYPE, false, Object.class, int.class),
+    SET_CALLER_CLASS_WRAPPER(INVOKEVIRTUAL, PhosphorStackFrame.class, "setCallerClassWrapper", Void.TYPE, false, Class.class),
+    GET_CALLER_CLASS_WRAPPER(INVOKEVIRTUAL, PhosphorStackFrame.class, "getCallerClassWrapper", Class.class, false, Class.class, Class.class),
     GET_ARG_WRAPPER_GENERIC(INVOKEVIRTUAL, PhosphorStackFrame.class, "getArgWrapper", Object.class, false, int.class, Object.class),
     GET_ARG_WRAPPER_OBJECT(INVOKEVIRTUAL, PhosphorStackFrame.class, "getArgWrapper", TaggedReferenceArray.class, false, int.class, Object[].class),
     GET_ARG_WRAPPER_BOOLEAN(INVOKEVIRTUAL, PhosphorStackFrame.class, "getArgWrapper", TaggedBooleanArray.class, false, int.class, boolean[].class),

--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/runtime/PhosphorStackFrame.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/runtime/PhosphorStackFrame.java
@@ -129,6 +129,9 @@ public class PhosphorStackFrame {
 
     @InvokedViaInstrumentation(record = TaintMethodRecord.GET_ARG_WRAPPER_GENERIC)
     public Object getArgWrapper(int idx, Object actual) {
+        if(actual instanceof Object[]){
+            return getArgWrapper(idx, (Object[]) actual);
+        }
         if (actual == null || !actual.getClass().isArray()) {
             return actual;
         }
@@ -532,5 +535,27 @@ public class PhosphorStackFrame {
             return new TaggedDoubleArray(unwrapped);
         }
         return ret;
+    }
+
+    @InvokedViaInstrumentation(record = TaintMethodRecord.GET_CALLER_CLASS_WRAPPER)
+    public Class getCallerClassWrapper(Class callerClassFromReflection, Class callerOfThisHelper){
+        if(callerClassFromReflection != callerOfThisHelper){
+            //Always return whatever Reflection.getCallerClass would have returned as long as it's not possibly the wrapper
+            return callerClassFromReflection;
+        }
+        //Look to see if we have a class there..
+        if(this.wrappedReturn instanceof Class){
+            return (Class) this.wrappedReturn;
+        }
+        return callerClassFromReflection;
+    }
+
+    /**
+     * For when a wrapped method will need to call getCallerClass, this will pass the caller to this wrapper along
+     * @param theRealCaller
+     */
+    @InvokedViaInstrumentation(record = TaintMethodRecord.SET_CALLER_CLASS_WRAPPER)
+    public void setCallerClassWrapper(Class theRealCaller){
+        this.wrappedReturn = theRealCaller;
     }
 }

--- a/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/LambdaObjTagITCase.java
+++ b/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/LambdaObjTagITCase.java
@@ -4,11 +4,15 @@ import edu.columbia.cs.psl.phosphor.runtime.MultiTainter;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.ServiceLoader;
 import java.util.function.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -132,6 +136,17 @@ public class LambdaObjTagITCase extends BaseMultiTaintClass {
 		staticRunnableMethodRan = false;
 		tryRunner(LambdaObjTagITCase::print);
 		Assert.assertTrue(staticRunnableMethodRan);
+	}
+
+	@Test
+	public void testBoundMethodHandleImpl() throws Throwable {
+		// Reproduces https://github.com/gmu-swe/phosphor/issues/188
+		final MethodType LOAD_CLASS_CLASSLOADER = MethodType.methodType(ServiceLoader.class, Class.class,
+				ClassLoader.class);
+		MethodHandles.Lookup publicLookup = MethodHandles.lookup();
+		final MethodHandle handle = publicLookup.findStatic(ServiceLoader.class, "load", LOAD_CLASS_CLASSLOADER);
+		final ServiceLoader serviceLoader = (ServiceLoader) handle.invokeExact(Test.class, Test.class.getClassLoader());
+		System.out.println(serviceLoader);
 	}
 
 }

--- a/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/LambdaObjTagITCase.java
+++ b/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/LambdaObjTagITCase.java
@@ -138,11 +138,11 @@ public class LambdaObjTagITCase extends BaseMultiTaintClass {
 		Assert.assertTrue(staticRunnableMethodRan);
 	}
 
+	static final MethodType LOAD_CLASS_CLASSLOADER = MethodType.methodType(ServiceLoader.class, Class.class,
+			ClassLoader.class);
 	@Test
 	public void testBoundMethodHandleImpl() throws Throwable {
 		// Reproduces https://github.com/gmu-swe/phosphor/issues/188
-		final MethodType LOAD_CLASS_CLASSLOADER = MethodType.methodType(ServiceLoader.class, Class.class,
-				ClassLoader.class);
 		MethodHandles.Lookup publicLookup = MethodHandles.lookup();
 		final MethodHandle handle = publicLookup.findStatic(ServiceLoader.class, "load", LOAD_CLASS_CLASSLOADER);
 		final ServiceLoader serviceLoader = (ServiceLoader) handle.invokeExact(Test.class, Test.class.getClassLoader());


### PR DESCRIPTION
This PR fixes issue #188 with these changes:
* Ensure that, when an unwrapped object is passed to an unistrumented wrapper (to a parameter of type java.lang.Object), that the object is wrapped before passing to the instrumented code. Exclude "Unsafe" from this handling, as it is necessary to still be able to use putReference etc. to set an underlying field
* For @CallerSensitive methods, collect the callerClass in the uninstrumented wrapper and pass it into the instrumented code
