### PR TITLE
Catch ClassCircularityError in unsafe propagators.

### DIFF
--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/LocalVariableManager.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/LocalVariableManager.java
@@ -281,9 +281,8 @@ public class LocalVariableManager extends OurLocalVariablesSorter implements Opc
             start = this.newStartLabel;
         }
         if (!Configuration.SKIP_LOCAL_VARIABLE_TABLE) {
-            int mappedIndex = remap(index, Type.getType(desc));
-            if (varToShadowVar.containsKey(mappedIndex)) {
-                int shadowVar = varToShadowVar.get(mappedIndex);
+            if (varToShadowVar.containsKey(index)) {
+                int shadowVar = varToShadowVar.get(index);
                 if (curLocalIdxToLVNode.containsKey(shadowVar)) {
                     LocalVariableNode n = curLocalIdxToLVNode.get(shadowVar);
                     uninstMV.visitLocalVariable(n.name, n.desc, n.signature, start, end, n.index);

--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/LocalVariableManager.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/LocalVariableManager.java
@@ -281,8 +281,9 @@ public class LocalVariableManager extends OurLocalVariablesSorter implements Opc
             start = this.newStartLabel;
         }
         if (!Configuration.SKIP_LOCAL_VARIABLE_TABLE) {
-            if (varToShadowVar.containsKey(index)) {
-                int shadowVar = varToShadowVar.get(index);
+            int mappedIndex = remap(index, Type.getType(desc));
+            if (varToShadowVar.containsKey(mappedIndex)) {
+                int shadowVar = varToShadowVar.get(mappedIndex);
                 if (curLocalIdxToLVNode.containsKey(shadowVar)) {
                     LocalVariableNode n = curLocalIdxToLVNode.get(shadowVar);
                     uninstMV.visitLocalVariable(n.name, n.desc, n.signature, start, end, n.index);

--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/runtime/RuntimeJDKInternalUnsafePropagator.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/runtime/RuntimeJDKInternalUnsafePropagator.java
@@ -26,7 +26,13 @@ public class RuntimeJDKInternalUnsafePropagator {
     private static SinglyLinkedList<OffsetPair> getOffsetPairs(UnsafeProxy unsafe, Class<?> targetClazz) {
         SinglyLinkedList<OffsetPair> list = new SinglyLinkedList<>();
         for (Class<?> clazz = targetClazz; clazz != null && !Object.class.equals(clazz); clazz = clazz.getSuperclass()) {
-            for (Field field : clazz.getDeclaredFields()) {
+            Field[] fields;
+            try {
+                fields = clazz.getDeclaredFields();
+            } catch (Throwable e) {
+                continue;
+            }
+            for (Field field : fields) {
                 try {
                     Class<?> fieldClazz = field.getType();
                     boolean isStatic = Modifier.isStatic(field.getModifiers());

--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/runtime/jdk/unsupported/RuntimeSunMiscUnsafePropagator.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/runtime/jdk/unsupported/RuntimeSunMiscUnsafePropagator.java
@@ -30,7 +30,13 @@ public class RuntimeSunMiscUnsafePropagator {
     private static SinglyLinkedList<OffsetPair> getOffsetPairs(UnsafeProxy unsafe, Class<?> targetClazz) {
         SinglyLinkedList<OffsetPair> list = new SinglyLinkedList<>();
         for(Class<?> clazz = targetClazz; clazz != null && !Object.class.equals(clazz); clazz = clazz.getSuperclass()) {
-            for(Field field : clazz.getDeclaredFields()) {
+            Field[] fields;
+            try {
+                fields = clazz.getDeclaredFields();
+            } catch (Throwable e) {
+                continue;
+            }
+            for(Field field : fields) {
                 try {
                     Class<?> fieldClazz = field.getType();
                     boolean isStatic = Modifier.isStatic(field.getModifiers());


### PR DESCRIPTION
I came across a strange exception yesterday (stack trace is attached below). Basically, hadoop implements a customized thread class `LocalFetcher`. When the class loader loads new classes in that thread,  the class loader uses a concurrent map to maintain locks for each class type.  The `ConcurrentHashMap` calls `ThreadLocalRandom.getProbe` which further calls `Unsafe.getInt(Thread.currentThread())`. https://github.com/openjdk/jdk/blob/jdk-16%2B36/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java#L2331 and https://github.com/openjdk/jdk/blob/4de3a6be9e60b9676f2199cd18eadb54a9d6e3fe/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java#L941 

The way phosphor handles getInt is to go over class declarations and find the corresponding field. Unfortunately, if the object contains a field whose type is not loaded yet. The loadClass routine will be triggered again. Then we will see a ClassCircularityError.


I failed to create a test case because the ConcurrentHashMap only calls `ThreadLocalRandom.getProbe` if there are concurrent updates. The hashmap updates is controlled by class loader and loading classes in parallel does not trigger the bug. 

My current fix is to swallow the exception because it seems hard for the Unsafe wrapper to know if it tries to load the same class twice. Please let me know if there is a better solution.


```
Caused by: java.lang.ClassCircularityError: org/apache/hadoop/security/ssl/SSLFactory                                                                                                                                             
        at java.base/java.lang.Class.getDeclaredFields0(Native Method)                                                                                                                                                            
        at java.base/java.lang.Class.privateGetDeclaredFields(Class.java:3229)                                                                                                                                                    
        at java.base/java.lang.Class.getDeclaredFields(Class.java:2335)                                                                                                                                                           
        at java.base/edu.columbia.cs.psl.phosphor.runtime.RuntimeJDKInternalUnsafePropagator.getOffsetPairs(RuntimeJDKInternalUnsafePropagator.java:29)                                                                           
        at java.base/edu.columbia.cs.psl.phosphor.runtime.RuntimeJDKInternalUnsafePropagator.getOffsetPair(RuntimeJDKInternalUnsafePropagator.java:101)                                                                           
        at java.base/edu.columbia.cs.psl.phosphor.runtime.RuntimeJDKInternalUnsafePropagator.getTag(RuntimeJDKInternalUnsafePropagator.java:137)                                                                                  
        at java.base/edu.columbia.cs.psl.phosphor.runtime.RuntimeJDKInternalUnsafePropagator.getInt(RuntimeJDKInternalUnsafePropagator.java:1393)                                                                                 
        at java.base/java.util.concurrent.ThreadLocalRandom.getProbe(ThreadLocalRandom.java:941)                                                                                                                                  
        at java.base/java.util.concurrent.ConcurrentHashMap.addCount(ConcurrentHashMap.java:2331)                                                                                                                                 
        at java.base/java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1075)                                                                                                                                   
        at java.base/java.util.concurrent.ConcurrentHashMap.putIfAbsent(ConcurrentHashMap.java:1541)                                                                                                                              
        at java.base/java.lang.ClassLoader.getClassLoadingLock(ClassLoader.java:665)                                                                                                                                              
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:646)                                                                                                                          
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:634)                                                                                                                                
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:182)                                                                                                                             
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:519)                                                                                                                                                        
        at java.base/java.lang.ClassLoader.defineClass1(Native Method)                                                                                                                                                            
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1010)                                                                                                                                                     
        at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)                                                                                                                                      
        at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:855)                                                                                                                              
        at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:753)                                                                                                               
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:676)                                                                                                                          
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:634)                                                                                                                                
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:182)                                                                                                                             
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:519)                                                                                                                                                        
        at java.base/java.lang.Class.getDeclaredFields0(Native Method)                                                                                                                                                            
        at java.base/java.lang.Class.privateGetDeclaredFields(Class.java:3229)                                                                                                                                                    
        at java.base/java.lang.Class.getDeclaredFields(Class.java:2335)                                                                                                                                                           
        at java.base/edu.columbia.cs.psl.phosphor.runtime.RuntimeJDKInternalUnsafePropagator.getOffsetPairs(RuntimeJDKInternalUnsafePropagator.java:29)                                                                           
        at java.base/edu.columbia.cs.psl.phosphor.runtime.RuntimeJDKInternalUnsafePropagator.getOffsetPair(RuntimeJDKInternalUnsafePropagator.java:101)                                                                           
        at java.base/edu.columbia.cs.psl.phosphor.runtime.RuntimeJDKInternalUnsafePropagator.getTag(RuntimeJDKInternalUnsafePropagator.java:137)                                                                                  
        at java.base/edu.columbia.cs.psl.phosphor.runtime.RuntimeJDKInternalUnsafePropagator.getInt(RuntimeJDKInternalUnsafePropagator.java:1393)                                                                                 
        at java.base/java.util.concurrent.ThreadLocalRandom.getProbe(ThreadLocalRandom.java:941)                                                                                                                                  
        at java.base/java.util.concurrent.ConcurrentHashMap.addCount(ConcurrentHashMap.java:2331)                                                                                                                                 
        at java.base/java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1075)                                                                                                                                   
        at java.base/java.util.concurrent.ConcurrentHashMap.putIfAbsent(ConcurrentHashMap.java:1541)                                                                                                                              
        at java.base/java.util.concurrent.ConcurrentHashMap.putIfAbsent(ConcurrentHashMap.java:1541)                                                                                                                              
        at java.base/java.lang.ClassLoader.getClassLoadingLock(ClassLoader.java:665)                                                                                                                                              
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:646)                                                                                                                          
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:634)                                                                                                                                
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:182)                                                                                                                             
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:519)                                                                                                                                                        
        at java.base/java.lang.Class.getDeclaredFields0(Native Method)                                                                                                                                                            
        at java.base/java.lang.Class.privateGetDeclaredFields(Class.java:3229)                                                                                                                                                    
        at java.base/java.lang.Class.getDeclaredFields(Class.java:2335)                                                                                                                                                           
        at java.base/edu.columbia.cs.psl.phosphor.runtime.RuntimeJDKInternalUnsafePropagator.getOffsetPairs(RuntimeJDKInternalUnsafePropagator.java:29)                                                                           
        at java.base/edu.columbia.cs.psl.phosphor.runtime.RuntimeJDKInternalUnsafePropagator.getOffsetPair(RuntimeJDKInternalUnsafePropagator.java:101)                                                                           
        at java.base/edu.columbia.cs.psl.phosphor.runtime.RuntimeJDKInternalUnsafePropagator.getTag(RuntimeJDKInternalUnsafePropagator.java:137)                                                                                  
        at java.base/edu.columbia.cs.psl.phosphor.runtime.RuntimeJDKInternalUnsafePropagator.getInt(RuntimeJDKInternalUnsafePropagator.java:1393)                                                                                 
        at java.base/java.util.concurrent.ThreadLocalRandom.getProbe(ThreadLocalRandom.java:941)                                                                                                                                  
        at java.base/java.util.concurrent.ConcurrentHashMap.addCount(ConcurrentHashMap.java:2331)                                                                                                                                 
        at java.base/java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1075)                                                                                                                                   
        at java.base/java.util.concurrent.ConcurrentHashMap.putIfAbsent(ConcurrentHashMap.java:1541)                                                                                                                              
        at java.base/java.lang.ClassLoader.getClassLoadingLock(ClassLoader.java:665)                                                                                                                                              
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:646)                                                                                                                          
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:634)                                                                                                                                
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:182)                                                                                                                             
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:519)                                                                                                                                                        
        at org.apache.hadoop.mapred.SpillRecord.<init>(SpillRecord.java:71)                                                                                                                                                       
        at org.apache.hadoop.mapred.SpillRecord.<init>(SpillRecord.java:62)                                                                                                                                                       
        at org.apache.hadoop.mapred.SpillRecord.<init>(SpillRecord.java:57)                                                                                                                                                       
        at org.apache.hadoop.mapreduce.task.reduce.LocalFetcher.copyMapOutput(LocalFetcher.java:127)                                                                                                                              
        at org.apache.hadoop.mapreduce.task.reduce.LocalFetcher.doCopy(LocalFetcher.java:105)                                                                                                                                     
        at org.apache.hadoop.mapreduce.task.reduce.LocalFetcher.run(LocalFetcher.java:88)                                                                                                                                         
```