### PR TITLE
[WIP] Fix crashes when passing arrays via reflection 

### DIFF
--- a/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/runtime/MethodHolder.java
+++ b/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/runtime/MethodHolder.java
@@ -35,6 +35,10 @@ public class MethodHolder {
         return RET_VALUE;
     }
 
+    public int example(Object b) {
+        return example((boolean[]) b);
+    }
+
     public int getLast(int a0, int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10,
                        int a11, int a12, int a13, int a14, int a15, int a16, int a17, int a18, int a19, int a20,
                        int a21, int a22, int a23, int a24, int a25, int a26, int a27, int a28, int a29, int a30,

--- a/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/runtime/MethodReflectionObjTagITCase.java
+++ b/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/runtime/MethodReflectionObjTagITCase.java
@@ -37,7 +37,8 @@ public class MethodReflectionObjTagITCase extends BaseMultiTaintClass {
         @DataPoints
         public static Class<?>[][] types = new Class<?>[][] {
                 {Boolean.TYPE},
-                {boolean[].class}
+                {boolean[].class},
+                {Object.class}
         };
 
         @DataPoints
@@ -51,7 +52,11 @@ public class MethodReflectionObjTagITCase extends BaseMultiTaintClass {
             Method method = MethodHolder.class.getMethod("example", types);
             Object[] args = new Object[types.length];
             for(int i = 0; i < types.length; i++) {
-                args[i] = types[i].isArray() ? supplier.getArray(taintArguments, types[i]) : supplier.getBoxedPrimitive(taintArguments, types[i]);
+                if (types[i] == Object.class) {
+                    args[i] = supplier.getArray(taintArguments, boolean[].class);
+                } else {
+                    args[i] = types[i].isArray() ? supplier.getArray(taintArguments, types[i]) : supplier.getBoxedPrimitive(taintArguments, types[i]);
+                }
             }
             Object result = method.invoke(holder, args);
             assertTrue("Expected integer to be returned from reflected method.", result instanceof Integer);
@@ -139,6 +144,7 @@ public class MethodReflectionObjTagITCase extends BaseMultiTaintClass {
             HashSet<Method> expected = new HashSet<>();
             expected.add(MethodHolder.class.getDeclaredMethod("example", Boolean.TYPE));
             expected.add(MethodHolder.class.getDeclaredMethod("example", boolean[].class));
+            expected.add(MethodHolder.class.getDeclaredMethod("example", Object.class));
             expected.add(MethodHolder.class.getDeclaredMethod("getLast", int.class, int.class,
                     int.class, int.class, int.class, int.class, int.class, int.class, int.class, int.class,
                     int.class, int.class, int.class, int.class, int.class, int.class, int.class, int.class,
@@ -154,11 +160,12 @@ public class MethodReflectionObjTagITCase extends BaseMultiTaintClass {
         /* Checks that synthetic equals and hashcode methods added by Phosphor are hidden from Class.getDeclaredMethods. */
         @Test
         public void testHashCodeAndEqualsHiddenFromGetDeclaredMethods() {
-            String[] methodNames = new String[]{"example", "example", "getLast"};
-            Class<?>[] returnTypes = new Class<?>[]{Integer.TYPE, Integer.TYPE, Integer.TYPE};
+            String[] methodNames = new String[]{"example", "example", "example", "getLast"};
+            Class<?>[] returnTypes = new Class<?>[]{Integer.TYPE, Integer.TYPE, Integer.TYPE, Integer.TYPE};
             Class<?>[][] paramTypes = new Class<?>[][]{
                     new Class<?>[]{Boolean.TYPE},
                     new Class<?>[]{boolean[].class},
+                    new Class<?>[]{Object.class},
                     new Class<?>[] {int.class,
                             int.class, int.class, int.class, int.class, int.class, int.class, int.class, int.class, int.class,
                             int.class, int.class, int.class, int.class, int.class, int.class, int.class, int.class, int.class,

--- a/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/runtime/ReflectionObjTagITCase.java
+++ b/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/runtime/ReflectionObjTagITCase.java
@@ -52,6 +52,11 @@ public class ReflectionObjTagITCase extends BaseMultiTaintClass {
 		}
 
 		@SuppressWarnings("unused")
+		public ConstructorHolder(Object bools) {
+			this.bools = (boolean[]) bools;
+		}
+
+		@SuppressWarnings("unused")
 		public ConstructorHolder(boolean[] bools, boolean bool) {
 			this.bool = bool;
 			this.bools = bools;
@@ -131,6 +136,15 @@ public class ReflectionObjTagITCase extends BaseMultiTaintClass {
 		assertNotNull(instance.bools);
 		assertTrue("Expected new instance from reflected constructor to have its field set.", instance.bools[0]);
 		assertNonNullTaint(MultiTainter.getTaint(instance.bools[0]));
+	}
+
+	@Test
+	public void testNewInstanceConstructorObjectArg() throws Exception {
+		Constructor<ConstructorHolder> cons = ConstructorHolder.class.getConstructor(Object.class);
+		boolean[] arr = new boolean[] {true, true};
+		ConstructorHolder instance = cons.newInstance(arr);
+		assertNotNull(instance.bools);
+		assertTrue("Expected new instance from reflected constructor to have its field set.", instance.bools[0]);
 	}
 
 	@Test


### PR DESCRIPTION
If a method signature has Object type and it receives an array via reflection, Phosphor cannot identify this and will lead to `java.lang.ClassCastException`.

Initially I was planning to simply expand this check for all methods https://github.com/gmu-swe/phosphor/blob/177ab28f96c4933a611e3ab8326047f59f335e92/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/TaintPassingMV.java#L139

It seems not working because it calls Phosphor inside JDK when JVM is initialized (and cause another crash). It seems that we need to maintain an allow list either:

1. call this wrapper for specific methods 
2. do not call this wrapper for specific methods

It seems plan 2 is more robust but building that list exhaustively is hard. Please let me know what you think and I'm happy to bring a patch.


Ps. if you want to see a realistic example, the class is https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/sun/security/x509/BasicConstraintsExtension.java#L114

