### PR TITLE
Only modify the modifiers in debug mode

### DIFF
--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/TaintTrackingClassVisitor.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/TaintTrackingClassVisitor.java
@@ -2,7 +2,6 @@ package edu.columbia.cs.psl.phosphor.instrumenter;
 
 import edu.columbia.cs.psl.phosphor.Configuration;
 import edu.columbia.cs.psl.phosphor.Instrumenter;
-import edu.columbia.cs.psl.phosphor.PreMain;
 import edu.columbia.cs.psl.phosphor.TaintUtils;
 import edu.columbia.cs.psl.phosphor.control.ControlFlowPropagationPolicy;
 import edu.columbia.cs.psl.phosphor.control.ControlFlowStack;
@@ -127,11 +126,6 @@ public class TaintTrackingClassVisitor extends ClassVisitor {
         }
 
         isLambda = name.contains("$$Lambda$");
-
-        // Debugging - no more package-protected
-        if (((access & Opcodes.ACC_PRIVATE) == 0) && PreMain.DEBUG) {
-            access = access | Opcodes.ACC_PUBLIC;
-        }
 
         if (superName != null && !superName.equals("java/lang/Object") && !Instrumenter.isIgnoredClass(superName)) {
             addTaintField = false;

--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/TaintTrackingClassVisitor.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/TaintTrackingClassVisitor.java
@@ -2,6 +2,7 @@ package edu.columbia.cs.psl.phosphor.instrumenter;
 
 import edu.columbia.cs.psl.phosphor.Configuration;
 import edu.columbia.cs.psl.phosphor.Instrumenter;
+import edu.columbia.cs.psl.phosphor.PreMain;
 import edu.columbia.cs.psl.phosphor.TaintUtils;
 import edu.columbia.cs.psl.phosphor.control.ControlFlowPropagationPolicy;
 import edu.columbia.cs.psl.phosphor.control.ControlFlowStack;
@@ -128,7 +129,7 @@ public class TaintTrackingClassVisitor extends ClassVisitor {
         isLambda = name.contains("$$Lambda$");
 
         // Debugging - no more package-protected
-        if ((access & Opcodes.ACC_PRIVATE) == 0) {
+        if (((access & Opcodes.ACC_PRIVATE) == 0) && PreMain.DEBUG) {
             access = access | Opcodes.ACC_PUBLIC;
         }
 


### PR DESCRIPTION
Some program may crash because the mismatched modifiers. So we should not modify them unless in debug mode. 

https://github.com/kleben/jersey/blob/master/core-common/src/main/java/org/glassfish/jersey/internal/inject/JerseyClassAnalyzer.java#L219