### PR TITLE
Java 11 Fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,13 +13,13 @@ jobs:
 #        java: [ '8', '11', '16', '17' ]
         java: [ '8', '11', '16' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build Phosphor
-        run: mvn -B -DskipTests install
+        run: mvn -B -ntp -DskipTests install
       - name: Setup java
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Run tests
-        run: mvn install -Ddacapo.skip=false
+        run: mvn install -ntp -Ddacapo.skip=false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
 #        java: [ '8', '11', '16', '17' ]
-        java: [ '8', '16' ]
+        java: [ '8', '11', '16' ]
     steps:
       - uses: actions/checkout@v2
       - name: Build Phosphor

--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/BasicSourceSinkManager.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/BasicSourceSinkManager.java
@@ -2,8 +2,8 @@ package edu.columbia.cs.psl.phosphor;
 
 import edu.columbia.cs.psl.phosphor.runtime.NonModifiableClassException;
 import edu.columbia.cs.psl.phosphor.struct.SinglyLinkedList;
-import edu.columbia.cs.psl.phosphor.struct.harmony.util.*;
 import edu.columbia.cs.psl.phosphor.struct.harmony.util.StringBuilder;
+import edu.columbia.cs.psl.phosphor.struct.harmony.util.*;
 import org.objectweb.asm.tree.ClassNode;
 
 import java.io.ByteArrayInputStream;
@@ -12,30 +12,21 @@ import java.util.Scanner;
 
 public class BasicSourceSinkManager extends SourceSinkManager {
 
-    private static ConcurrentHashMap<String, Object> sourceLabels = new ConcurrentHashMap<>();
-
+    private static final Map<String, Object> sourceLabels = new HashMap<>();
     // Maps class names to a set of all the methods listed as sources for the class
-    private static ConcurrentHashMap<String, Set<String>> sources = new ConcurrentHashMap<>();
+    private static final Map<String, Set<String>> sources = new HashMap<>();
     // Maps class names to a set of all the methods listed as sinks for the class
-    private static ConcurrentHashMap<String, Set<String>> sinks = new ConcurrentHashMap<>();
+    private static final Map<String, Set<String>> sinks = new HashMap<>();
     // Maps class names to a set of all the methods listed as taintThrough methods for the class
-    private static ConcurrentHashMap<String, Set<String>> taintThrough = new ConcurrentHashMap<>();
-    // Maps class names to a set of all methods listed as sources for the class or one of its supertypes or superinterfaces
-    private static ConcurrentHashMap<String, Set<String>> inheritedSources = new ConcurrentHashMap<>();
-    // Maps class names to a set of all methods listed as sinks for the class or one of its supertypes or superinterfaces
-    private static ConcurrentHashMap<String, Set<String>> inheritedSinks = new ConcurrentHashMap<>();
-    // Maps class names to a set of all methods listed as taintThrough methods for the class or one of its supertypes or superinterfaces
-    private static ConcurrentHashMap<String, Set<String>> inheritedTaintThrough = new ConcurrentHashMap<>();
-
+    private static final Map<String, Set<String>> taintThrough = new HashMap<>();
     // Maps class names to sets of class instances
     private static final Map<String, Set<Class<?>>> classMap = new HashMap<>();
-
-    /* Reads source, sink and taintThrough methods from their files into their respective maps. */
-    public static void loadTaintMethods() {
-        readTaintMethods(Instrumenter.sourcesFile, AutoTaint.SOURCE);
-        readTaintMethods(Instrumenter.sinksFile, AutoTaint.SINK);
-        readTaintMethods(Instrumenter.taintThroughFile, AutoTaint.TAINT_THROUGH);
-    }
+    // Maps class names to a set of all methods listed as sources for the class or one of its supertypes or superinterfaces
+    private static Map<String, Set<String>> inheritedSources = new HashMap<>();
+    // Maps class names to a set of all methods listed as sinks for the class or one of its supertypes or superinterfaces
+    private static Map<String, Set<String>> inheritedSinks = new HashMap<>();
+    // Maps class names to a set of all methods listed as taintThrough methods for the class or one of its supertypes or superinterfaces
+    private static Map<String, Set<String>> inheritedTaintThrough = new HashMap<>();
 
     /* Private constructor ensures that only one instance of BasicSourceSinkManager is ever created. */
     private BasicSourceSinkManager() {
@@ -43,68 +34,84 @@ public class BasicSourceSinkManager extends SourceSinkManager {
 
     @Override
     public boolean isSourceOrSinkOrTaintThrough(Class<?> clazz) {
-        if(clazz.getName() == null) {
-            return false;
+        synchronized (BasicSourceSinkManager.class) {
+            String className = clazz.getName().replace(".", "/");
+            // This class has a sink, source or taintThrough method
+            return !getAutoTaintMethods(className, sinks, inheritedSinks).isEmpty()
+                    || !getAutoTaintMethods(className, sources, inheritedSources).isEmpty()
+                    || !getAutoTaintMethods(className, taintThrough, inheritedTaintThrough).isEmpty();
         }
-        String className = clazz.getName().replace(".", "/");
-        // This class has a sink, source or taintThrough method
-        return !getAutoTaintMethods(className, sinks, inheritedSinks).isEmpty()
-                || !getAutoTaintMethods(className, sources, inheritedSources).isEmpty()
-                || !getAutoTaintMethods(className, taintThrough, inheritedTaintThrough).isEmpty();
     }
 
     @Override
     public Object getLabel(String str) {
-        return sourceLabels.get(str);
+        synchronized (BasicSourceSinkManager.class) {
+            return sourceLabels.get(str);
+        }
     }
 
     @Override
     public boolean isTaintThrough(String str) {
-        if(str.startsWith("[")) {
-            return false;
-        } else {
-            String[] parsed = str.split("\\.");
-            // Check if the set of taintThrough methods for the class name contains the method name
-            return getAutoTaintMethods(parsed[0], taintThrough, inheritedTaintThrough).contains(parsed[1]);
+        synchronized (BasicSourceSinkManager.class) {
+            if (str.startsWith("[")) {
+                return false;
+            } else {
+                String[] parsed = str.split("\\.");
+                // Check if the set of taintThrough methods for the class name contains the method name
+                return getAutoTaintMethods(parsed[0], taintThrough, inheritedTaintThrough).contains(parsed[1]);
+            }
         }
     }
 
     @Override
     public boolean isSource(String str) {
-        if(str.startsWith("[")) {
-            return false;
-        } else {
-            String[] parsed = str.split("\\.");
-            // Check if the set of source methods for the class name contains the method name
-            if(getAutoTaintMethods(parsed[0], sources, inheritedSources).contains(parsed[1])) {
-                String baseSource = findSuperTypeAutoTaintProvider(parsed[0], parsed[1], sources, inheritedSources);
-                if(!sourceLabels.containsKey(str)) {
-                    sourceLabels.put(str, sourceLabels.get(String.format("%s.%s", baseSource, parsed[1])));
-                }
-                return true;
-            } else {
+        synchronized (BasicSourceSinkManager.class) {
+            if (str.startsWith("[")) {
                 return false;
+            } else {
+                String[] parsed = str.split("\\.");
+                // Check if the set of source methods for the class name contains the method name
+                if (getAutoTaintMethods(parsed[0], sources, inheritedSources).contains(parsed[1])) {
+                    String baseSource = findSuperTypeAutoTaintProvider(parsed[0], parsed[1], sources, inheritedSources);
+                    if (!sourceLabels.containsKey(str)) {
+                        sourceLabels.put(str, sourceLabels.get(String.format("%s.%s", baseSource, parsed[1])));
+                    }
+                    return true;
+                } else {
+                    return false;
+                }
             }
         }
     }
 
     @Override
     public boolean isSink(String str) {
-        if(str.startsWith("[")) {
-            return false;
-        } else {
-            String[] parsed = str.split("\\.");
-            // Check if the set of sink methods for the class name contains the method name
-            return getAutoTaintMethods(parsed[0], sinks, inheritedSinks).contains(parsed[1]);
+        synchronized (BasicSourceSinkManager.class) {
+            if (str.startsWith("[")) {
+                return false;
+            } else {
+                String[] parsed = str.split("\\.");
+                // Check if the set of sink methods for the class name contains the method name
+                return getAutoTaintMethods(parsed[0], sinks, inheritedSinks).contains(parsed[1]);
+            }
         }
     }
 
     /* Returns the name of sink method from which the specified method inherited its sink property or null if the specified
      * method is not a sink. */
     public String getBaseSink(String str) {
-        String[] parsed = str.split("\\.");
-        String baseSink = findSuperTypeAutoTaintProvider(parsed[0], parsed[1], sinks, inheritedSinks);
-        return baseSink == null ? null : String.format("%s.%s", baseSink, parsed[1]);
+        synchronized (BasicSourceSinkManager.class) {
+            String[] parsed = str.split("\\.");
+            String baseSink = findSuperTypeAutoTaintProvider(parsed[0], parsed[1], sinks, inheritedSinks);
+            return baseSink == null ? null : String.format("%s.%s", baseSink, parsed[1]);
+        }
+    }
+
+    /* Reads source, sink and taintThrough methods from their files into their respective maps. */
+    public static synchronized void loadTaintMethods() {
+        readTaintMethods(Instrumenter.sourcesFile, AutoTaint.SOURCE);
+        readTaintMethods(Instrumenter.sinksFile, AutoTaint.SINK);
+        readTaintMethods(Instrumenter.taintThroughFile, AutoTaint.TAINT_THROUGH);
     }
 
     /* Provides access to the single instance of BasicSourceSinkManager */
@@ -117,8 +124,8 @@ public class BasicSourceSinkManager extends SourceSinkManager {
     private static synchronized void readTaintMethods(InputStream src, AutoTaint type) {
         Scanner s = null;
         String lastLine = null;
-        ConcurrentHashMap<String, Set<String>> baseMethods;
-        switch(type) {
+        Map<String, Set<String>> baseMethods;
+        switch (type) {
             case SOURCE:
                 baseMethods = sources;
                 break;
@@ -129,31 +136,31 @@ public class BasicSourceSinkManager extends SourceSinkManager {
                 baseMethods = taintThrough;
         }
         try {
-            if(src != null) {
+            if (src != null) {
                 s = new Scanner(src);
-                while(s.hasNextLine()) {
+                while (s.hasNextLine()) {
                     String line = s.nextLine();
                     lastLine = line;
-                    if(!line.startsWith("#") && !line.isEmpty()) {
+                    if (!line.startsWith("#") && !line.isEmpty()) {
                         String[] parsed = line.split("\\.");
-                        if(!baseMethods.containsKey(parsed[0])) {
+                        if (!baseMethods.containsKey(parsed[0])) {
                             baseMethods.put(parsed[0], new HashSet<String>());
                         }
                         baseMethods.get(parsed[0]).add(parsed[1]);
-                        if(type.equals(AutoTaint.SOURCE)) {
+                        if (type.equals(AutoTaint.SOURCE)) {
                             sourceLabels.put(line, line);
                         }
                     }
                 }
             }
-        } catch(Throwable e) {
+        } catch (Throwable e) {
             System.err.printf("Unable to parse %s file: %s\n", type.name, src);
-            if(lastLine != null) {
+            if (lastLine != null) {
                 System.err.printf("Last line read: '%s'\n", lastLine);
             }
             throw new RuntimeException(e);
         } finally {
-            if(s != null) {
+            if (s != null) {
                 s.close();
             }
         }
@@ -163,7 +170,7 @@ public class BasicSourceSinkManager extends SourceSinkManager {
      * change as a result of a call to replaceAutoTaintMethods. */
     public static synchronized void recordClass(Class<?> clazz) {
         String key = clazz.getName().replace(".", "/");
-        if(!classMap.containsKey(key)) {
+        if (!classMap.containsKey(key)) {
             classMap.put(key, new HashSet<>());
         }
         classMap.get(key).add(clazz);
@@ -171,7 +178,7 @@ public class BasicSourceSinkManager extends SourceSinkManager {
 
     public static synchronized java.util.LinkedList<String> replaceAutoTaintMethods(Iterable<String> src, AutoTaint type) {
         StringBuilder builder = new StringBuilder();
-        for(String s : src) {
+        for (String s : src) {
             builder.append(s).append("\n");
         }
         return replaceAutoTaintMethods(new ByteArrayInputStream(builder.toString().getBytes()), type);
@@ -181,35 +188,35 @@ public class BasicSourceSinkManager extends SourceSinkManager {
      * any class with a method whose status as an autoTaint methods of the specified type has changed. Returns a list of
      * the replaced base autoTaint methods of the specified type. */
     public static synchronized java.util.LinkedList<String> replaceAutoTaintMethods(InputStream src, AutoTaint type) {
-        ConcurrentHashMap<String, Set<String>> baseMethods;
-        ConcurrentHashMap<String, Set<String>> inheritedMethods;
-        ConcurrentHashMap<String, Set<String>> prevInheritedMethods;
-        switch(type) {
+        Map<String, Set<String>> baseMethods;
+        Map<String, Set<String>> inheritedMethods;
+        Map<String, Set<String>> prevInheritedMethods;
+        switch (type) {
             case SOURCE:
                 baseMethods = sources;
                 prevInheritedMethods = inheritedSources;
                 // Clear the map of inherited or derived autoTaint methods of the specified type
-                inheritedMethods = new ConcurrentHashMap<>();
+                inheritedMethods = new HashMap<>();
                 inheritedSources = inheritedMethods;
                 break;
             case SINK:
                 baseMethods = sinks;
                 prevInheritedMethods = inheritedSinks;
                 // Clear the map of inherited or derived autoTaint methods of the specified type
-                inheritedMethods = new ConcurrentHashMap<>();
+                inheritedMethods = new HashMap<>();
                 inheritedSinks = inheritedMethods;
                 break;
             default:
                 baseMethods = taintThrough;
                 prevInheritedMethods = inheritedTaintThrough;
                 // Clear the map of inherited or derived autoTaint methods of the specified type
-                inheritedMethods = new ConcurrentHashMap<>();
+                inheritedMethods = new HashMap<>();
                 inheritedTaintThrough = inheritedMethods;
         }
         // Reconstruct the original set of base methods
         java.util.LinkedList<String> prevBaseMethods = new java.util.LinkedList<>();
-        for(String className : baseMethods.keySet()) {
-            for(String methodName : baseMethods.get(className)) {
+        for (String className : baseMethods.keySet()) {
+            for (String methodName : baseMethods.get(className)) {
                 prevBaseMethods.add(className + "." + methodName);
             }
         }
@@ -218,19 +225,19 @@ public class BasicSourceSinkManager extends SourceSinkManager {
         readTaintMethods(src, type);
         // Retransform any class that has a method that changed from being a autoTaint methods of the specified type
         // to a not being an autoTaint methods of the specified type or vice versa
-        for(String className : prevInheritedMethods.keySet()) {
+        for (String className : prevInheritedMethods.keySet()) {
             Set<String> autoTaintMethods = getAutoTaintMethods(className, baseMethods, inheritedMethods);
-            if(!autoTaintMethods.equals(prevInheritedMethods.get(className))) {
+            if (!autoTaintMethods.equals(prevInheritedMethods.get(className))) {
                 // Set of autoTaint methods for this class changed
                 try {
-                    if(classMap.containsKey(className)) {
-                        for(Class<?> clazz : classMap.get(className)) {
+                    if (classMap.containsKey(className)) {
+                        for (Class<?> clazz : classMap.get(className)) {
                             PreMain.getInstrumentationHelper().retransformClasses(clazz);
                         }
                     }
-                } catch(NonModifiableClassException e) {
+                } catch (NonModifiableClassException e) {
                     //
-                } catch(Throwable t) {
+                } catch (Throwable t) {
                     // Make sure that any other type of exception is printed
                     t.printStackTrace();
                     throw t;
@@ -244,27 +251,27 @@ public class BasicSourceSinkManager extends SourceSinkManager {
      * the class or interface with the specified slash-separated string class name. A method is considered to be an auto
      * taint method if the method is present in the set of base auto taint methods for either the specified class or a supertype of the
      * specified class. Previously determined auto taint methods are stored in inheritedMethods. */
-    private static synchronized Set<String> getAutoTaintMethods(String className, ConcurrentHashMap<String, Set<String>> baseMethods,
-                                                                ConcurrentHashMap<String, Set<String>> inheritedMethods) {
-        if(inheritedMethods.containsKey(className)) {
+    private static synchronized Set<String> getAutoTaintMethods(String className, Map<String, Set<String>> baseMethods,
+                                                                Map<String, Set<String>> inheritedMethods) {
+        if (inheritedMethods.containsKey(className)) {
             // The auto taint methods for this class have already been determined.
             return inheritedMethods.get(className);
         } else {
             // Recursively build the set of auto taint methods for this class
             Set<String> set = new HashSet<>();
-            if(baseMethods.containsKey(className)) {
+            if (baseMethods.containsKey(className)) {
                 // Add any methods from this class that are directly listed as auto taint methods
                 set.addAll(baseMethods.get(className));
             }
             ClassNode cn = Instrumenter.getClassNode(className);
-            if(cn != null) {
-                if(cn.interfaces != null) {
+            if (cn != null) {
+                if (cn.interfaces != null) {
                     // Add all auto taint methods from interfaces implemented by this class
-                    for(Object inter : cn.interfaces) {
-                        set.addAll(getAutoTaintMethods((String) inter, baseMethods, inheritedMethods));
+                    for (String inter : cn.interfaces) {
+                        set.addAll(getAutoTaintMethods(inter, baseMethods, inheritedMethods));
                     }
                 }
-                if(cn.superName != null && !cn.superName.equals("java/lang/Object")) {
+                if (cn.superName != null && !cn.superName.equals("java/lang/Object")) {
                     // Add all auto taint methods from the superclass of this class
                     set.addAll(getAutoTaintMethods(cn.superName, baseMethods, inheritedMethods));
                 }
@@ -277,26 +284,26 @@ public class BasicSourceSinkManager extends SourceSinkManager {
     /* Returns the string class name of the supertype of the class or interface with specified string class name from which
      * its method with the specified method name derived its status as an auto taint (i.e. source, sink or taintThrough)
      * method. */
-    private static synchronized String findSuperTypeAutoTaintProvider(String className, String methodName, ConcurrentHashMap<String,
-            Set<String>> baseMethods, ConcurrentHashMap<String, Set<String>> inheritedMethods) {
+    private static synchronized String findSuperTypeAutoTaintProvider(String className, String methodName, Map<String,
+            Set<String>> baseMethods, Map<String, Set<String>> inheritedMethods) {
         SinglyLinkedList<String> queue = new SinglyLinkedList<>();
         queue.enqueue(className);
-        while(!queue.isEmpty()) {
+        while (!queue.isEmpty()) {
             String curClassName = queue.pop();
             // Check that the current class actually has an inherited auto taint method with the target method name
-            if(inheritedMethods.containsKey(curClassName) && inheritedMethods.get(curClassName).contains(methodName)) {
-                if(baseMethods.containsKey(curClassName) && baseMethods.get(curClassName).contains(methodName)) {
+            if (inheritedMethods.containsKey(curClassName) && inheritedMethods.get(curClassName).contains(methodName)) {
+                if (baseMethods.containsKey(curClassName) && baseMethods.get(curClassName).contains(methodName)) {
                     return curClassName;
                 }
                 ClassNode cn = Instrumenter.getClassNode(curClassName);
-                if(cn != null) {
-                    if(cn.interfaces != null) {
+                if (cn != null) {
+                    if (cn.interfaces != null) {
                         // Enqueue interfaces implemented by the current class
-                        for(Object inter : cn.interfaces) {
-                            queue.enqueue((String) inter);
+                        for (String inter : cn.interfaces) {
+                            queue.enqueue(inter);
                         }
                     }
-                    if(cn.superName != null && !cn.superName.equals("java/lang/Object")) {
+                    if (cn.superName != null && !cn.superName.equals("java/lang/Object")) {
                         // Enqueue the superclass of the current class
                         queue.enqueue(cn.superName);
                     }

--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/BasicSourceSinkManager.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/BasicSourceSinkManager.java
@@ -2,13 +2,12 @@ package edu.columbia.cs.psl.phosphor;
 
 import edu.columbia.cs.psl.phosphor.runtime.NonModifiableClassException;
 import edu.columbia.cs.psl.phosphor.struct.SinglyLinkedList;
-import edu.columbia.cs.psl.phosphor.struct.harmony.util.ConcurrentHashMap;
-import edu.columbia.cs.psl.phosphor.struct.harmony.util.HashSet;
-import edu.columbia.cs.psl.phosphor.struct.harmony.util.Set;
+import edu.columbia.cs.psl.phosphor.struct.harmony.util.*;
 import org.objectweb.asm.tree.ClassNode;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.lang.StringBuilder;
 import java.util.Scanner;
 
 public class BasicSourceSinkManager extends SourceSinkManager {
@@ -19,7 +18,7 @@ public class BasicSourceSinkManager extends SourceSinkManager {
     private static ConcurrentHashMap<String, Set<String>> sources = new ConcurrentHashMap<>();
     // Maps class names to a set of all the methods listed as sinks for the class
     private static ConcurrentHashMap<String, Set<String>> sinks = new ConcurrentHashMap<>();
-    // Maps class names to a set of all the  methods listed as taintThrough methods for the class
+    // Maps class names to a set of all the methods listed as taintThrough methods for the class
     private static ConcurrentHashMap<String, Set<String>> taintThrough = new ConcurrentHashMap<>();
     // Maps class names to a set of all methods listed as sources for the class or one of its supertypes or superinterfaces
     private static ConcurrentHashMap<String, Set<String>> inheritedSources = new ConcurrentHashMap<>();
@@ -29,7 +28,7 @@ public class BasicSourceSinkManager extends SourceSinkManager {
     private static ConcurrentHashMap<String, Set<String>> inheritedTaintThrough = new ConcurrentHashMap<>();
 
     // Maps class names to sets of class instances
-    private static ConcurrentHashMap<String, Set<Class<?>>> classMap = new ConcurrentHashMap<>();
+    private static final Map<String, Set<Class<?>>> classMap = new HashMap<>();
 
     /* Reads source, sink and taintThrough methods from their files into their respective maps. */
     public static void loadTaintMethods() {
@@ -163,11 +162,11 @@ public class BasicSourceSinkManager extends SourceSinkManager {
     /* Stores the specified class instance so that it can last be used to retransform the class if it's autoTaint methods
      * change as a result of a call to replaceAutoTaintMethods. */
     public static synchronized void recordClass(Class<?> clazz) {
-        if(clazz.getName() != null) {
-            String key = clazz.getName().replace(".", "/");
-            classMap.putIfAbsent(key, new HashSet<>());
-            classMap.get(key).add(clazz);
+        String key = clazz.getName().replace(".", "/");
+        if(!classMap.containsKey(key)) {
+            classMap.put(key, new HashSet<>());
         }
+        classMap.get(key).add(clazz);
     }
 
     public static synchronized java.util.LinkedList<String> replaceAutoTaintMethods(Iterable<String> src, AutoTaint type) {

--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/BasicSourceSinkManager.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/BasicSourceSinkManager.java
@@ -3,11 +3,11 @@ package edu.columbia.cs.psl.phosphor;
 import edu.columbia.cs.psl.phosphor.runtime.NonModifiableClassException;
 import edu.columbia.cs.psl.phosphor.struct.SinglyLinkedList;
 import edu.columbia.cs.psl.phosphor.struct.harmony.util.*;
+import edu.columbia.cs.psl.phosphor.struct.harmony.util.StringBuilder;
 import org.objectweb.asm.tree.ClassNode;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.lang.StringBuilder;
 import java.util.Scanner;
 
 public class BasicSourceSinkManager extends SourceSinkManager {

--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/PhosphorPatcher.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/PhosphorPatcher.java
@@ -1,0 +1,171 @@
+package edu.columbia.cs.psl.phosphor;
+
+import edu.columbia.cs.psl.phosphor.instrumenter.ConfigurationEmbeddingMV;
+import edu.columbia.cs.psl.phosphor.runtime.jdk.unsupported.UnsafeProxy;
+import org.objectweb.asm.*;
+import org.objectweb.asm.commons.ModuleHashesAttribute;
+import org.objectweb.asm.commons.ModuleResolutionAttribute;
+import org.objectweb.asm.commons.ModuleTargetAttribute;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.ModuleExportNode;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Set;
+
+public class PhosphorPatcher {
+    private final boolean patchUnsafeNames;
+
+    public PhosphorPatcher(InputStream unsafeContent) throws IOException {
+        this.patchUnsafeNames = shouldPatchUnsafeNames(unsafeContent);
+    }
+
+    public byte[] patch(String name, byte[] content) throws IOException {
+        if (name.equals("edu/columbia/cs/psl/phosphor/Configuration.class")) {
+            return setConfigurationVersion(new ByteArrayInputStream(content));
+        } else if (name.equals("edu/columbia/cs/psl/phosphor/runtime/RuntimeJDKInternalUnsafePropagator.class")) {
+            return transformUnsafePropagator(new ByteArrayInputStream(content),
+                    "jdk/internal/misc/Unsafe", patchUnsafeNames);
+        } else {
+            return content;
+        }
+    }
+
+    public byte[] transformBaseModuleInfo(InputStream in, Set<String> packages) {
+        try {
+            ClassNode classNode = new ClassNode();
+            ClassReader cr = new ClassReader(in);
+            Attribute[] attributes = new Attribute[]{new ModuleTargetAttribute(),
+                    new ModuleResolutionAttribute(),
+                    new ModuleHashesAttribute()};
+            cr.accept(classNode, attributes, 0);
+            // Add exports
+            for (String packageName : packages) {
+                classNode.module.exports.add(new ModuleExportNode(packageName, 0, null));
+            }
+            // Add packages
+            classNode.module.packages.addAll(packages);
+            ClassWriter cw = new ClassWriter(0);
+            classNode.accept(cw);
+            return cw.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static boolean shouldPatchUnsafeNames(InputStream in) throws IOException {
+        ClassNode cn = new ClassNode();
+        new ClassReader(in).accept(cn, 0);
+        for (MethodNode mn : cn.methods) {
+            if (mn.name.contains("putReference")) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Modify {@link Configuration} to set {@link Configuration#IS_JAVA_8} to false.
+     * This flag must be set correctly in order to boot the JVM.
+     */
+    private static byte[] setConfigurationVersion(InputStream is) throws IOException {
+        ClassReader cr = new ClassReader(is);
+        ClassWriter cw = new ClassWriter(cr, 0);
+        ClassVisitor cv = new ClassVisitor(Configuration.ASM_VERSION, cw) {
+            @Override
+            public MethodVisitor visitMethod(int access, String name, String descriptor, String signature,
+                                             String[] exceptions) {
+                MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
+                if (name.equals("<clinit>")) {
+                    return new ConfigurationEmbeddingMV(mv);
+                } else {
+                    return mv;
+                }
+            }
+        };
+        cr.accept(cv, 0);
+        return cw.toByteArray();
+    }
+
+    public static byte[] transformUnsafePropagator(InputStream in, String unsafeInternalName,
+                                                   boolean patchUnsafeNames) throws IOException {
+        ClassReader cr = new ClassReader(in);
+        ClassWriter cw = new ClassWriter(cr, 0);
+        ClassVisitor cv = new UnsafePatchingCV(cw, unsafeInternalName, patchUnsafeNames);
+        cr.accept(cv, 0);
+        return cw.toByteArray();
+    }
+
+    private static class UnsafePatchingCV extends ClassVisitor {
+        private static final String UNSAFE_PROXY_INTERNAL_NAME = Type.getInternalName(UnsafeProxy.class);
+        private static final String UNSAFE_PROXY_DESC = Type.getDescriptor(UnsafeProxy.class);
+        private final String unsafeDesc;
+        private final boolean patchNames;
+        private final String unsafeInternalName;
+
+        public UnsafePatchingCV(ClassWriter cw, String unsafeInternalName, boolean patchNames) {
+            super(Configuration.ASM_VERSION, cw);
+            this.unsafeInternalName = unsafeInternalName;
+            this.unsafeDesc = "L" + unsafeInternalName + ";";
+            this.patchNames = patchNames;
+        }
+
+        private String patchInternalName(String name) {
+            return UNSAFE_PROXY_INTERNAL_NAME.equals(name) ? unsafeInternalName : name;
+        }
+
+        private String patchDesc(String desc) {
+            return desc == null ? null : desc.replace(UNSAFE_PROXY_DESC, unsafeDesc);
+        }
+
+        private String patchMethodName(String owner, String name) {
+            return patchNames && owner.equals(UNSAFE_PROXY_INTERNAL_NAME) ?
+                    name.replace("Reference", "Object") : name;
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+            MethodVisitor mv = super.visitMethod(access, name, patchDesc(descriptor), patchDesc(signature), exceptions);
+            return new MethodVisitor(api, mv) {
+                @Override
+                public void visitFrame(int type, int numLocal, Object[] local, int numStack, Object[] stack) {
+                    for (int i = 0; i < numLocal; i++) {
+                        if (local[i] instanceof String) {
+                            local[i] = patchInternalName((String) local[i]);
+                        }
+                    }
+                    for (int i = 0; i < numStack; i++) {
+                        if (stack[i] instanceof String) {
+                            stack[i] = patchInternalName((String) stack[i]);
+                        }
+                    }
+                    super.visitFrame(type, numLocal, local, numStack, stack);
+                }
+
+                @Override
+                public void visitFieldInsn(int opcode, String owner, String name, String descriptor) {
+                    super.visitFieldInsn(opcode, patchInternalName(owner), name, patchDesc(descriptor));
+                }
+
+                @Override
+                public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+                    super.visitMethodInsn(opcode, patchInternalName(owner), patchMethodName(owner, name),
+                            patchDesc(descriptor), isInterface);
+                }
+
+                @Override
+                public void visitTypeInsn(int opcode, String type) {
+                    super.visitTypeInsn(opcode, patchInternalName(type));
+                }
+
+                @Override
+                public void visitLocalVariable(String name, String descriptor, String signature, Label start, Label end,
+                                               int index) {
+                    super.visitLocalVariable(name, patchDesc(descriptor), signature, start, end, index);
+                }
+            };
+        }
+    }
+}

--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/InstrumentedJREProxyGenerator.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/InstrumentedJREProxyGenerator.java
@@ -2,12 +2,14 @@ package edu.columbia.cs.psl.phosphor.instrumenter;
 
 
 import edu.columbia.cs.psl.phosphor.Configuration;
-import edu.columbia.cs.psl.phosphor.Instrumenter;
+import edu.columbia.cs.psl.phosphor.PhosphorPatcher;
 import org.objectweb.asm.*;
 import org.objectweb.asm.commons.GeneratorAdapter;
 import org.objectweb.asm.util.CheckClassAdapter;
 
-import java.io.*;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -21,7 +23,8 @@ public class InstrumentedJREProxyGenerator {
 
         String pathToUnsafePropagator = outputDir + "/edu/columbia/cs/psl/phosphor/runtime/jdk/unsupported/RuntimeSunMiscUnsafePropagator.class";
         InputStream sunMiscUnsafeIn = new FileInputStream(pathToUnsafePropagator);
-        byte[] instrumentedUnsafe = Instrumenter.transformRuntimeUnsafePropagator(sunMiscUnsafeIn, "sun/misc/Unsafe");
+        byte[] instrumentedUnsafe = PhosphorPatcher.transformUnsafePropagator(sunMiscUnsafeIn,
+                "sun/misc/Unsafe", false);
         Files.write(Paths.get(pathToUnsafePropagator), instrumentedUnsafe);
 
         for (String clazz : CLASSES) {

--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/ReflectionHidingMV.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/ReflectionHidingMV.java
@@ -519,8 +519,10 @@ public class ReflectionHidingMV extends MethodVisitor implements Opcodes {
                     }
                 }
                 desc = "(L" + owner + ";" + desc.substring(1);
-                // Java 11 uses get/putObject instead of Reference
-                name = name.replace("Object", "Reference");
+                if (isUnsafeIntrinsic(owner, name, descWithoutStackFrame)) {
+                    // Java 11 uses get/putObject instead of Reference
+                    name = name.replace("Object", "Reference");
+                }
                 super.visitMethodInsn(Opcodes.INVOKESTATIC, getRuntimeUnsafePropogatorClassName(), name, desc, false);
                 return;
             } else if (isUnsafeFieldSetter(opcode, owner, name, args, nameWithoutSuffix)) {

--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/ReflectionHidingMV.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/ReflectionHidingMV.java
@@ -159,6 +159,8 @@ public class ReflectionHidingMV extends MethodVisitor implements Opcodes {
         if (!Instrumenter.isUnsafeClass(owner)) {
             return false;
         }
+        // Java 11 uses get/putObject instead of Reference
+        name = name.replace("Object", "Reference");
         switch (desc) {
             case "(Ljava/lang/Object;JLjava/lang/Object;)V":
                 switch (name) {
@@ -517,6 +519,8 @@ public class ReflectionHidingMV extends MethodVisitor implements Opcodes {
                     }
                 }
                 desc = "(L" + owner + ";" + desc.substring(1);
+                // Java 11 uses get/putObject instead of Reference
+                name = name.replace("Object", "Reference");
                 super.visitMethodInsn(Opcodes.INVOKESTATIC, getRuntimeUnsafePropogatorClassName(), name, desc, false);
                 return;
             } else if (isUnsafeFieldSetter(opcode, owner, name, args, nameWithoutSuffix)) {
@@ -628,6 +632,7 @@ public class ReflectionHidingMV extends MethodVisitor implements Opcodes {
         if (Configuration.IS_JAVA_8) {
             return "getObject".equals(methodName) || "getObjectVolatile".equals(methodName);
         }
+        // TODO Java 11?
         return "getReference".equals(methodName) || "getReferenceVolatile".equals(methodName);
     }
 }

--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/TaintAdapter.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/TaintAdapter.java
@@ -734,6 +734,12 @@ public class TaintAdapter extends MethodVisitor implements Opcodes {
                     super.visitInsn(POP);
                     super.visitInsn(ACONST_NULL);
                 }
+            } else if(TaintUtils.isWrappedType(expected)) {
+                // Clear the arg wrapper
+                pushPhosphorStackFrame();
+                super.visitInsn(ACONST_NULL);
+                push(idxOfThisArg);
+                SET_ARG_WRAPPER.delegateVisit(mv);
             }
             super.visitVarInsn(t.getOpcode(ISTORE), tmp[i]);
         }

--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/TaintMethodRecord.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/TaintMethodRecord.java
@@ -62,6 +62,7 @@ public enum TaintMethodRecord implements MethodRecord {
     START_STACK_FRAME_TRACKING(INVOKESTATIC, PhosphorStackFrame.class, "initialize", Void.TYPE, false),
     PREPARE_FOR_CALL_DEBUG(INVOKEVIRTUAL, PhosphorStackFrame.class, "prepareForCall", Void.TYPE, false, String.class),
     PREPARE_FOR_CALL_FAST(INVOKEVIRTUAL, PhosphorStackFrame.class, "prepareForCall", Void.TYPE, false, int.class),
+    PREPARE_FOR_CALL_PATCHED(INVOKEVIRTUAL, PhosphorStackFrame.class, "prepareForCallPatched", Void.TYPE, false, int.class),
     PREPARE_FOR_CALL_PREV(INVOKEVIRTUAL, PhosphorStackFrame.class, "prepareForCallPrev", Void.TYPE, false),
     CHECK_STACK_FRAME_TARGET(INVOKEVIRTUAL, PhosphorStackFrame.class, "checkTarget", Void.TYPE, false, String.class),
     STACK_FRAME_FOR_METHOD_DEBUG(INVOKESTATIC, PhosphorStackFrame.class, "forMethod", PhosphorStackFrame.class, false, String.class),

--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/UninstrumentedCompatMV.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/UninstrumentedCompatMV.java
@@ -338,7 +338,7 @@ public class UninstrumentedCompatMV extends TaintAdapter {
             super.visitLdcInsn(name + desc.substring(0, 1 + desc.indexOf(')')));
             PREPARE_FOR_CALL_DEBUG.delegateVisit(mv);
         } else {
-            push(PhosphorStackFrame.hashForDesc(name + desc.substring(0, 1 + desc.indexOf(')'))));
+            push(PhosphorStackFrame.computeFrameHash(name, desc.substring(0, 1 + desc.indexOf(')'))));
             PREPARE_FOR_CALL_FAST.delegateVisit(mv);
         }
         Type[] args = Type.getArgumentTypes(desc);

--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/runtime/TaintSourceWrapper.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/runtime/TaintSourceWrapper.java
@@ -272,7 +272,7 @@ public class TaintSourceWrapper<T extends AutoTaintLabel> {
                     if(Configuration.DEBUG_STACK_FRAME_WRAPPERS) {
                         frame.prepareForCall("charAt(I)");
                     } else{
-                        frame.prepareForCall(PhosphorStackFrame.hashForDesc("charAt(I)"));
+                        frame.prepareForCall(PhosphorStackFrame.computeFrameHash("charAt", "(I)"));
                     }
                     char c = str.charAt(i);
                     Taint tag = frame.getReturnTaint();

--- a/phosphor-instrument-jigsaw/src/main/java/edu/columbia/cs/psl/jigsaw/phosphor/instrumenter/PhosphorPacker.java
+++ b/phosphor-instrument-jigsaw/src/main/java/edu/columbia/cs/psl/jigsaw/phosphor/instrumenter/PhosphorPacker.java
@@ -1,0 +1,74 @@
+package edu.columbia.cs.psl.jigsaw.phosphor.instrumenter;
+
+import edu.columbia.cs.psl.phosphor.PhosphorPatcher;
+import jdk.tools.jlink.plugin.ResourcePool;
+import jdk.tools.jlink.plugin.ResourcePoolBuilder;
+import jdk.tools.jlink.plugin.ResourcePoolEntry;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+class PhosphorPacker {
+    private final File phosphorJar;
+    private final PhosphorPatcher patcher;
+
+    PhosphorPacker(ResourcePool pool, File phosphorJar) {
+        if (phosphorJar == null) {
+            throw new NullPointerException();
+        }
+        this.phosphorJar = phosphorJar;
+        ResourcePoolEntry entry = pool.findEntry("/java.base/jdk/internal/misc/Unsafe.class")
+                .orElseThrow(() -> new IllegalArgumentException("Unable to find entry for jdk/internal/misc/Unsafe"));
+        try (InputStream in = entry.content()) {
+            this.patcher = new PhosphorPatcher(in);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to read entry for jdk/internal/misc/Unsafe", e);
+        }
+    }
+
+    private boolean shouldInclude(String name) {
+        return !name.startsWith("edu/columbia/cs/psl/jigsaw/phosphor/instrumenter")
+                && !name.endsWith("module-info.class")
+                && !name.startsWith("org/")
+                && !name.startsWith("edu/columbia/cs/psl/phosphor/runtime/jdk/unsupported")
+                && name.endsWith(".class");
+    }
+
+    ResourcePoolEntry pack(ResourcePoolEntry entry, ResourcePoolBuilder out) {
+        // Transform java.base's module-info.class file and pack Phosphor classes into java.base
+        try {
+            Set<String> packages = packClasses(out);
+            try (InputStream in = entry.content()) {
+                return entry.copyWithContent(patcher.transformBaseModuleInfo(in, packages));
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Set<String> packClasses(ResourcePoolBuilder out) throws IOException {
+        // Pack the Phosphor JAR into the resource pool
+        // Return the set of packages for packed classes
+        Set<String> packages = new HashSet<>();
+        try (ZipFile zip = new ZipFile(phosphorJar)) {
+            Enumeration<? extends ZipEntry> entries = zip.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = entries.nextElement();
+                if (shouldInclude(entry.getName())) {
+                    try (InputStream is = zip.getInputStream(entry)) {
+                        byte[] content = patcher.patch(entry.getName(), is.readAllBytes());
+                        out.add(ResourcePoolEntry.create("/java.base/" + entry.getName(), content));
+                    }
+                    packages.add(entry.getName().substring(0, entry.getName().lastIndexOf('/')));
+                }
+            }
+        }
+        return packages;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -94,14 +94,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${maven.checkstyle.version}</version>
                 <configuration>


### PR DESCRIPTION
* Removed double declaration of compiler plugin from aggregator POM.
* Factored packing of Phosphor into java.base module out of PhosphorJLinkPlugin into new class PhosphorPacker.
* Factored patching of Phosphor class from Instrumenter into new class PhosphorPatcher.
* Fixed issue with missing Unsafe#put/getReference methods in Java 11 causing JVM to crash.
* Fixed issue with intrinsic Unsafe#put/getObject methods in Java 11 causing JVM to crash.
* Fixed circular class loading in Java 11 from use of ConcurrentHashMap in BasicSourceSinkManager.
* Fixed tag loss related to VarHandles in Java 11 by patching the descriptor for the frame's hash.
* Added Java 11 to GHA workflow matrix.
* Increased version of checkout action in GHA workflow to v3.
* Added no -ntp (--no-transfer-progress) flag to maven commands in GHA workflow.
* Fixed issue with Phosphor wrapper argument not being cleared for null values resulting in old values being passed.