### PR TITLE
Fixed failure when instrumenting classes with an annotation containing an Enum-type value

### DIFF
--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/PhosphorPatcher.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/PhosphorPatcher.java
@@ -1,6 +1,7 @@
 package edu.columbia.cs.psl.phosphor;
 
 import edu.columbia.cs.psl.phosphor.instrumenter.ConfigurationEmbeddingMV;
+import edu.columbia.cs.psl.phosphor.instrumenter.TaintMethodRecord;
 import edu.columbia.cs.psl.phosphor.runtime.jdk.unsupported.UnsafeProxy;
 import org.objectweb.asm.*;
 import org.objectweb.asm.commons.ModuleHashesAttribute;
@@ -28,6 +29,8 @@ public class PhosphorPatcher {
         } else if (name.equals("edu/columbia/cs/psl/phosphor/runtime/RuntimeJDKInternalUnsafePropagator.class")) {
             return transformUnsafePropagator(new ByteArrayInputStream(content),
                     "jdk/internal/misc/Unsafe", patchUnsafeNames);
+        } else if (AsmPatchingCV.isApplicable(name)) {
+            return AsmPatchingCV.patch(content);
         } else {
             return content;
         }
@@ -166,6 +169,45 @@ public class PhosphorPatcher {
                     super.visitLocalVariable(name, patchDesc(descriptor), signature, start, end, index);
                 }
             };
+        }
+    }
+
+    private static class AsmPatchingCV extends ClassVisitor {
+        private static final String ASM_PREFIX = "edu/columbia/cs/psl/phosphor/org/objectweb/asm/";
+        private static final Type OBJECT_TYPE = Type.getType(Object.class);
+
+        public AsmPatchingCV(ClassWriter cw) {
+            super(Configuration.ASM_VERSION, cw);
+        }
+
+        @Override
+        public MethodVisitor visitMethod(
+                int access, String name, String descriptor, String signature, String[] exceptions) {
+            MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
+            return new MethodVisitor(api, mv) {
+
+                @Override
+                public void visitMethodInsn(
+                        int opcode, String owner, String name, String descriptor, boolean isInterface) {
+                    super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+                    // Ensure that the return value is unwrapped if necessary
+                    if (owner.startsWith("java/") && OBJECT_TYPE.equals(Type.getReturnType(descriptor))) {
+                        TaintMethodRecord.TAINTED_REFERENCE_ARRAY_UNWRAP.delegateVisit(mv);
+                    }
+                }
+            };
+        }
+
+        public static byte[] patch(byte[] classFileBuffer) {
+            ClassReader cr = new ClassReader(classFileBuffer);
+            ClassWriter cw = new ClassWriter(cr, 0);
+            ClassVisitor cv = new AsmPatchingCV(cw);
+            cr.accept(cv, 0);
+            return cw.toByteArray();
+        }
+
+        public static boolean isApplicable(String className) {
+            return className.startsWith(ASM_PREFIX);
         }
     }
 }

--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/TaintMethodRecord.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/instrumenter/TaintMethodRecord.java
@@ -124,7 +124,9 @@ public enum TaintMethodRecord implements MethodRecord {
     TAINTED_REFERENCE_ARRAY_GET(INVOKEVIRTUAL, TaggedReferenceArray.class, "get", Object.class, false, int.class, Taint.class, PhosphorStackFrame.class),
     TAINTED_SHORT_ARRAY_GET(INVOKEVIRTUAL, TaggedShortArray.class, "get", short.class, false, int.class, Taint.class, PhosphorStackFrame.class),
     // Methods from TaintSourceWrapper
-    AUTO_TAINT(INVOKEVIRTUAL, TaintSourceWrapper.class, "autoTaint", Object.class, false, Object.class, String.class, String.class, int.class);
+    AUTO_TAINT(INVOKEVIRTUAL, TaintSourceWrapper.class, "autoTaint", Object.class, false, Object.class, String.class, String.class, int.class),
+    // TaggedReferenceArray
+    TAINTED_REFERENCE_ARRAY_UNWRAP(INVOKESTATIC, TaggedReferenceArray.class, "unwrap", Object.class, false, Object.class);
 
     private final int opcode;
     private final String owner;

--- a/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/struct/TaggedReferenceArray.java
+++ b/Phosphor/src/main/java/edu/columbia/cs/psl/phosphor/struct/TaggedReferenceArray.java
@@ -12,8 +12,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.lang.reflect.Array;
 
-import static edu.columbia.cs.psl.phosphor.instrumenter.TaintMethodRecord.TAINTED_REFERENCE_ARRAY_GET;
-import static edu.columbia.cs.psl.phosphor.instrumenter.TaintMethodRecord.TAINTED_REFERENCE_ARRAY_SET;
+import static edu.columbia.cs.psl.phosphor.instrumenter.TaintMethodRecord.*;
 
 public final class TaggedReferenceArray extends TaggedArray {
 
@@ -233,11 +232,15 @@ public final class TaggedReferenceArray extends TaggedArray {
         return new TaggedReferenceArray(lengthTaint, array);
     }
 
-
     public static Object[] unwrap(TaggedReferenceArray obj) {
         if (obj != null) {
             return obj.val;
         }
         return null;
+    }
+
+    @InvokedViaInstrumentation(record = TAINTED_REFERENCE_ARRAY_UNWRAP)
+    public static Object unwrap(Object obj) {
+        return (obj instanceof TaggedReferenceArray) ? ((TaggedReferenceArray) obj).val : obj;
     }
 }

--- a/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/AnnotationInstCase.java
+++ b/integration-tests/src/test/java/edu/columbia/cs/psl/test/phosphor/AnnotationInstCase.java
@@ -1,0 +1,37 @@
+package edu.columbia.cs.psl.test.phosphor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+
+public class AnnotationInstCase {
+    @Test
+    public void testEnum() throws ReflectiveOperationException {
+        Method method = Example.class.getDeclaredMethod("x");
+        ExampleAnnotation annotation = method.getAnnotation(ExampleAnnotation.class);
+        Assert.assertNotNull(annotation);
+        Assert.assertEquals(ExampleAnnotation.Color.BLUE, annotation.color());
+    }
+
+    public static class Example {
+        @ExampleAnnotation(color = ExampleAnnotation.Color.BLUE)
+        void x() {}
+    }
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface ExampleAnnotation {
+        Color color();
+
+        enum Color {
+            RED,
+            BLUE,
+            GREEN;
+        }
+    }
+}


### PR DESCRIPTION
## Failure Description
Phosphor instrumentation throws an `IllegalArgumentException` when processing a class containing an annotation with a value of an `Enum` type.

### Stack Trace
```
java.lang.IllegalArgumentException: value edu.columbia.cs.psl.phosphor.struct.TaggedReferenceArray@770d3326
        at java.base/edu.columbia.cs.psl.phosphor.org.objectweb.asm.SymbolTable.addConstant(SymbolTable.java:525)
        at java.base/edu.columbia.cs.psl.phosphor.org.objectweb.asm.AnnotationWriter.visit(AnnotationWriter.java:259)
        at java.base/edu.columbia.cs.psl.phosphor.org.objectweb.asm.tree.AnnotationNode.accept(AnnotationNode.java:226)
        at java.base/edu.columbia.cs.psl.phosphor.org.objectweb.asm.tree.AnnotationNode.accept(AnnotationNode.java:193)
        at java.base/edu.columbia.cs.psl.phosphor.org.objectweb.asm.tree.MethodNode.accept(MethodNode.java:674)
        at java.base/edu.columbia.cs.psl.phosphor.instrumenter.TaintLoadCoercer$UninstTaintLoadCoercerMN.visitEnd(TaintLoadCoercer.java:235)
```

### Cause
ASM's `AnnotationNode` class is not instrumented by Phosphor. `AnnotationNode` uses an instance of the Java Class Library class `java.util.ArrayList` to store name-value pairs for an annotation. `java.util.ArrayList` is instrumented by Phosphor. `Enum` values are stored by `AnnotationNode` as `String` arrays. `ArrayList` will wrap these `String` arrays into `TaggedReferenceArray` instances and before storing them. When the `AnnotationNode` goes to process the `Enum` value, it receives a `TaggedReferenceArray` from the `ArrayList` instead of a `String` array.

## Changes
* Added previously failing test case demonstrating instrumentation failure when processing annotations containing `Enum` values.
* Fixed instrumentation failure when processing annotations containing `Enum` values by adding a class visitor to `PhosphorPatcher` to unwrap `TaggedReferenceArray` instances returned by certain JCL methods in ASM classes.